### PR TITLE
Bootstrap test suite: 35 unittest tests + CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,20 @@
+name: tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  unittest:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Run unittest suite
+        run: python -m unittest discover -s tests -v

--- a/README.md
+++ b/README.md
@@ -74,3 +74,13 @@ python analyze_image.py photo.gif --json    # raw API response
 Supported formats: JPEG, PNG, GIF, WebP (max 20 MB). Default model: `claude-sonnet-4-6`.
 
 Exit codes: `0` success · `2` bad args / missing key · `3` image error · `4` API error · `5` network error.
+
+## Running Tests
+
+The test suite uses only the standard library:
+
+```bash
+python -m unittest discover -s tests -v
+```
+
+Tests cover persistence, slot-conflict logic, email notifications (with mocked SMTP), search, and the `analyze_image.py` CLI's argument and format validation paths.

--- a/tests/test_analyze_image.py
+++ b/tests/test_analyze_image.py
@@ -1,0 +1,104 @@
+"""Tests for analyze_image.py.
+
+The script runs entirely at module import time, so we exercise it via
+subprocess to keep the tests honest. Network paths are not invoked here —
+those would require either real keys or a local HTTP fake.
+"""
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent.parent / "analyze_image.py"
+
+
+def _run(args, env=None):
+    """Run the script with a fresh, controlled environment."""
+    base_env = {"PATH": os.environ.get("PATH", "")}
+    if env:
+        base_env.update(env)
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        env=base_env,
+        timeout=15,
+    )
+
+
+class CliArgumentTests(unittest.TestCase):
+    def test_no_args_prints_usage_and_exits_nonzero(self):
+        result = _run([])
+        self.assertNotEqual(result.returncode, 0)
+        # Usage string from the module docstring.
+        self.assertIn("Usage", result.stdout + result.stderr)
+
+    def test_help_flag_prints_usage(self):
+        for flag in ("-h", "--help"):
+            with self.subTest(flag=flag):
+                result = _run([flag])
+                self.assertNotEqual(result.returncode, 0)
+                combined = result.stdout + result.stderr
+                self.assertIn("Usage", combined)
+                self.assertIn("ANTHROPIC_API_KEY", combined)
+
+
+class ApiKeyTests(unittest.TestCase):
+    def test_missing_api_key_errors_out(self):
+        with tempfile.NamedTemporaryFile(suffix=".png") as f:
+            # Strip ANTHROPIC_API_KEY by passing a minimal env.
+            result = _run([f.name])
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("ANTHROPIC_API_KEY", result.stdout + result.stderr)
+
+
+class FormatValidationTests(unittest.TestCase):
+    def test_unsupported_extension_errors_out(self):
+        with tempfile.NamedTemporaryFile(suffix=".bmp") as f:
+            result = _run([f.name], env={"ANTHROPIC_API_KEY": "fake-key"})
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("unsupported format", result.stdout + result.stderr)
+
+    def test_extension_lookup_is_case_insensitive(self):
+        # Upper-case .JPG should not be reported as unsupported. We can't fully
+        # run the script (no network/key), but we can confirm that the script
+        # gets past the extension check by giving a missing file: it should
+        # then fail trying to open the file rather than rejecting the format.
+        with tempfile.TemporaryDirectory() as d:
+            ghost = Path(d) / "ghost.JPG"  # uppercase, doesn't exist
+            result = _run([str(ghost)], env={"ANTHROPIC_API_KEY": "fake-key"})
+        self.assertNotEqual(result.returncode, 0)
+        combined = result.stdout + result.stderr
+        self.assertNotIn("unsupported format", combined)
+        # Should fail on file open instead.
+        self.assertTrue(
+            "No such file" in combined
+            or "FileNotFoundError" in combined
+            or "Errno 2" in combined,
+            msg=f"unexpected output: {combined!r}",
+        )
+
+
+class MediaMapTests(unittest.TestCase):
+    """Sanity check that the supported-format table matches docs."""
+
+    EXPECTED = {
+        ".jpg": "image/jpeg",
+        ".jpeg": "image/jpeg",
+        ".png": "image/png",
+        ".gif": "image/gif",
+        ".webp": "image/webp",
+    }
+
+    def test_readme_supported_formats_match_script(self):
+        text = SCRIPT.read_text()
+        for ext, mime in self.EXPECTED.items():
+            self.assertIn(ext, text)
+            self.assertIn(mime, text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_barber_booking_agent.py
+++ b/tests/test_barber_booking_agent.py
@@ -1,0 +1,342 @@
+"""Unit tests for barber_booking_agent.
+
+Stdlib-only: run with `python -m unittest discover -s tests`.
+"""
+
+import io
+import json
+import os
+import smtplib
+import sys
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+# Make the project root importable when run from anywhere.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import barber_booking_agent as bba  # noqa: E402
+
+
+def _sample_data():
+    return {
+        "barbers": {
+            "Alice": {
+                "slots": ["09:00", "10:00"],
+                "services": {"Haircut": 25.0},
+                "email": "alice@example.com",
+            },
+            "Bob": {"slots": ["11:00"], "services": {}, "email": ""},
+        },
+        "bookings": [
+            {
+                "barber": "Alice",
+                "client": "Carol",
+                "client_email": "carol@example.com",
+                "date": "2099-01-01",
+                "time": "09:00",
+                "service": "Haircut",
+                "price": 25.0,
+                "booked_at": "2099-01-01T08:00:00",
+            }
+        ],
+    }
+
+
+class PersistenceTests(unittest.TestCase):
+    """load_bookings / save_bookings."""
+
+    def setUp(self):
+        self._cwd = os.getcwd()
+        self._tmp = Path(self._cwd) / "_tmp_test_persistence"
+        self._tmp.mkdir(exist_ok=True)
+        os.chdir(self._tmp)
+
+    def tearDown(self):
+        os.chdir(self._cwd)
+        for p in self._tmp.iterdir():
+            p.unlink()
+        self._tmp.rmdir()
+
+    def test_missing_file_returns_skeleton(self):
+        self.assertFalse(Path(bba.DATA_FILE).exists())
+        data = bba.load_bookings()
+        self.assertEqual(data, {"barbers": {}, "bookings": []})
+
+    def test_round_trip_preserves_all_fields(self):
+        original = _sample_data()
+        bba.save_bookings(original)
+        loaded = bba.load_bookings()
+        self.assertEqual(loaded, original)
+
+    def test_save_writes_indented_json(self):
+        bba.save_bookings({"barbers": {}, "bookings": []})
+        text = Path(bba.DATA_FILE).read_text()
+        # indent=2 means at least one newline + leading spaces
+        self.assertIn("\n  ", text)
+
+
+class SlotLogicTests(unittest.TestCase):
+    """_is_slot_taken."""
+
+    def setUp(self):
+        self.data = _sample_data()
+
+    def test_taken_when_exact_match(self):
+        self.assertTrue(bba._is_slot_taken(self.data, "Alice", "2099-01-01", "09:00"))
+
+    def test_free_when_different_time(self):
+        self.assertFalse(bba._is_slot_taken(self.data, "Alice", "2099-01-01", "10:00"))
+
+    def test_free_when_different_date(self):
+        self.assertFalse(bba._is_slot_taken(self.data, "Alice", "2099-01-02", "09:00"))
+
+    def test_free_when_different_barber(self):
+        self.assertFalse(bba._is_slot_taken(self.data, "Bob", "2099-01-01", "09:00"))
+
+    def test_free_when_no_bookings(self):
+        empty = {"barbers": {}, "bookings": []}
+        self.assertFalse(bba._is_slot_taken(empty, "Alice", "2099-01-01", "09:00"))
+
+
+class BarberEmailTests(unittest.TestCase):
+    def setUp(self):
+        self.data = _sample_data()
+
+    def test_returns_email_when_present(self):
+        self.assertEqual(bba._barber_email(self.data, "Alice"), "alice@example.com")
+
+    def test_returns_empty_when_not_set(self):
+        self.assertEqual(bba._barber_email(self.data, "Bob"), "")
+
+    def test_returns_empty_when_unknown(self):
+        self.assertEqual(bba._barber_email(self.data, "Nobody"), "")
+
+
+class EmailNotificationTests(unittest.TestCase):
+    """send_email_notification."""
+
+    SMTP_ENV = {
+        "SMTP_HOST": "smtp.example.com",
+        "SMTP_PORT": "587",
+        "SMTP_USER": "user@example.com",
+        "SMTP_PASS": "pw",
+    }
+
+    def test_returns_false_when_env_missing(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertFalse(
+                bba.send_email_notification("to@example.com", "subj", "body")
+            )
+
+    def test_returns_false_when_recipient_missing(self):
+        with mock.patch.dict(os.environ, self.SMTP_ENV, clear=True):
+            self.assertFalse(bba.send_email_notification("", "subj", "body"))
+
+    def test_smtp_called_when_env_complete(self):
+        with mock.patch.dict(os.environ, self.SMTP_ENV, clear=True):
+            with mock.patch.object(smtplib, "SMTP") as smtp_cls:
+                ok = bba.send_email_notification("to@example.com", "subj", "body")
+        self.assertTrue(ok)
+        smtp_cls.assert_called_once_with("smtp.example.com", 587)
+        instance = smtp_cls.return_value.__enter__.return_value
+        instance.starttls.assert_called_once()
+        instance.login.assert_called_once_with("user@example.com", "pw")
+        instance.sendmail.assert_called_once()
+        sender, recipients, raw = instance.sendmail.call_args[0]
+        self.assertEqual(sender, "user@example.com")
+        self.assertEqual(recipients, ["to@example.com"])
+        self.assertIn("Subject: subj", raw)
+        self.assertIn("body", raw)
+
+    def test_smtp_from_overrides_user_as_sender(self):
+        env = {**self.SMTP_ENV, "SMTP_FROM": "noreply@example.com"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            with mock.patch.object(smtplib, "SMTP") as smtp_cls:
+                bba.send_email_notification("to@example.com", "s", "b")
+        instance = smtp_cls.return_value.__enter__.return_value
+        sender, _, raw = instance.sendmail.call_args[0]
+        self.assertEqual(sender, "noreply@example.com")
+        self.assertIn("From: noreply@example.com", raw)
+
+    def test_returns_false_on_smtp_exception(self):
+        with mock.patch.dict(os.environ, self.SMTP_ENV, clear=True):
+            with mock.patch.object(smtplib, "SMTP", side_effect=OSError("boom")):
+                buf = io.StringIO()
+                with redirect_stdout(buf):
+                    ok = bba.send_email_notification("to@example.com", "s", "b")
+        self.assertFalse(ok)
+        self.assertIn("Email failed", buf.getvalue())
+
+
+class NotifyTests(unittest.TestCase):
+    """notify() console output."""
+
+    def test_prints_barber_tag(self):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            bba.notify("barber", "Alice", "hello")
+        self.assertIn("[BARBER]", buf.getvalue())
+        self.assertIn("To: Alice", buf.getvalue())
+        self.assertIn("Message: hello", buf.getvalue())
+
+    def test_prints_client_tag_for_anything_else(self):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            bba.notify("client", "Carol", "hi")
+        self.assertIn("[CLIENT]", buf.getvalue())
+
+    def test_skips_email_when_no_address(self):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            bba.notify("client", "Carol", "hi", email=None)
+        # no email skipped/sent line should appear
+        self.assertNotIn("Email", buf.getvalue())
+
+
+class ViewBookingsTests(unittest.TestCase):
+    """view_bookings partitioning and formatting."""
+
+    def test_empty_bookings_message(self):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            bba.view_bookings({"barbers": {}, "bookings": []})
+        self.assertIn("No bookings yet.", buf.getvalue())
+
+    def test_partitions_upcoming_and_past(self):
+        data = {
+            "barbers": {},
+            "bookings": [
+                {
+                    "barber": "Alice",
+                    "client": "Past",
+                    "date": "1999-01-01",
+                    "time": "09:00",
+                    "service": None,
+                    "price": 0,
+                },
+                {
+                    "barber": "Alice",
+                    "client": "Future",
+                    "date": "2999-01-01",
+                    "time": "09:00",
+                    "service": "Haircut",
+                    "price": 25.0,
+                },
+            ],
+        }
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            bba.view_bookings(data)
+        out = buf.getvalue()
+        self.assertIn("Upcoming:", out)
+        self.assertIn("Past:", out)
+        # Future booking shows service tag, past one does not.
+        self.assertIn("[Haircut $25.00]", out)
+        self.assertIn("Future with Alice", out)
+        self.assertIn("Past with Alice", out)
+
+
+class SearchBookingsTests(unittest.TestCase):
+    """search_bookings input/output."""
+
+    def _run(self, data, term):
+        buf = io.StringIO()
+        with mock.patch("builtins.input", return_value=term):
+            with redirect_stdout(buf):
+                bba.search_bookings(data)
+        return buf.getvalue()
+
+    def test_match_by_barber_case_insensitive(self):
+        out = self._run(_sample_data(), "alice")
+        self.assertIn("Found 1 booking(s):", out)
+        self.assertIn("Carol with Alice", out)
+
+    def test_match_by_client_partial(self):
+        out = self._run(_sample_data(), "car")
+        self.assertIn("Found 1 booking(s):", out)
+
+    def test_no_matches(self):
+        out = self._run(_sample_data(), "zzz")
+        self.assertIn("No bookings found matching 'zzz'", out)
+
+    def test_empty_term(self):
+        out = self._run(_sample_data(), "   ")
+        self.assertIn("Search term cannot be empty.", out)
+
+
+class RegisterBarberTests(unittest.TestCase):
+    """register_barber: end-to-end with mocked input/save."""
+
+    def setUp(self):
+        self._cwd = os.getcwd()
+        self._tmp = Path(self._cwd) / "_tmp_register"
+        self._tmp.mkdir(exist_ok=True)
+        os.chdir(self._tmp)
+
+    def tearDown(self):
+        os.chdir(self._cwd)
+        for p in self._tmp.iterdir():
+            p.unlink()
+        self._tmp.rmdir()
+
+    def test_registers_with_slots_and_services(self):
+        data = {"barbers": {}, "bookings": []}
+        inputs = iter(
+            [
+                "Alice",        # name
+                "alice@x.com",  # email
+                "09:00",        # slot
+                "10:00",        # slot
+                "done",
+                "Haircut",      # service name
+                "25.00",        # price
+                "done",
+            ]
+        )
+        with mock.patch("builtins.input", lambda *_a, **_kw: next(inputs)):
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                bba.register_barber(data)
+        self.assertIn("Alice", data["barbers"])
+        self.assertEqual(data["barbers"]["Alice"]["slots"], ["09:00", "10:00"])
+        self.assertEqual(data["barbers"]["Alice"]["services"], {"Haircut": 25.0})
+        self.assertEqual(data["barbers"]["Alice"]["email"], "alice@x.com")
+        # Persistence side-effect: bookings.json should have been written.
+        self.assertTrue(Path(bba.DATA_FILE).exists())
+        on_disk = json.loads(Path(bba.DATA_FILE).read_text())
+        self.assertIn("Alice", on_disk["barbers"])
+
+    def test_rejects_empty_name(self):
+        data = {"barbers": {}, "bookings": []}
+        with mock.patch("builtins.input", return_value=""):
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                bba.register_barber(data)
+        self.assertEqual(data["barbers"], {})
+
+    def test_rejects_duplicate(self):
+        data = _sample_data()
+        with mock.patch("builtins.input", return_value="Alice"):
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                bba.register_barber(data)
+        self.assertIn("already registered", buf.getvalue())
+
+    def test_invalid_slot_format_skipped(self):
+        data = {"barbers": {}, "bookings": []}
+        inputs = iter(
+            [
+                "Alice", "", "9am", "09:00", "done", "done",  # bad slot then good slot
+            ]
+        )
+        with mock.patch("builtins.input", lambda *_a, **_kw: next(inputs)):
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                bba.register_barber(data)
+        self.assertEqual(data["barbers"]["Alice"]["slots"], ["09:00"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The repo had **0% test coverage**. This PR bootstraps a stdlib-only test suite (no new runtime or dev dependencies) and adds CI.

- **35 tests** across two modules, all passing locally on Python 3.11 in 0.31 s
- Uses only `unittest` + `unittest.mock` — matches the project's "no external dependencies" philosophy
- GitHub Actions workflow runs the suite on push and PR across Python 3.9 / 3.10 / 3.11 / 3.12

## What's covered

**`barber_booking_agent.py` (29 tests)**

| Area | Tests |
| --- | --- |
| Persistence (`load_bookings` / `save_bookings`) | missing-file skeleton, round-trip preserves all fields, indented JSON output |
| Slot conflicts (`_is_slot_taken`) | exact match, different time / date / barber, empty data |
| `_barber_email` | present, empty, unknown |
| `send_email_notification` | missing env, missing recipient, SMTP called with correct args, `SMTP_FROM` overrides sender, exception path returns False |
| `notify` | barber/client tags, skips email line when no address |
| `view_bookings` | empty message, partitions upcoming vs past, formats service/price |
| `search_bookings` | case-insensitive barber/client match, no matches, empty term |
| `register_barber` | full happy path with persistence, empty name rejected, duplicate rejected, invalid slot format skipped |

**`analyze_image.py` (6 tests)** — driven via `subprocess` since the script runs at import time

- No-args prints usage and exits non-zero
- `-h` / `--help` print usage including `ANTHROPIC_API_KEY`
- Missing `ANTHROPIC_API_KEY` errors out with the documented message
- Unsupported extension (`.bmp`) is rejected
- Extension lookup is case-insensitive (`.JPG` passes the format check)
- Supported-format table is internally consistent

## Not covered (deliberately, follow-up tickets)

- `book_appointment`, `cancel_booking`, `reschedule_booking` — these workflow functions tightly couple `input()`, `print()`, and persistence; testing them well needs a small refactor to inject I/O. Filing as a follow-up rather than monkey-patching `builtins.input` for long input scripts.
- The Anthropic API call path in `analyze_image.py` — would need a local HTTP fake or `urllib.request.urlopen` patch (script form makes the latter awkward).

## Test plan

- [x] `python -m unittest discover -s tests -v` passes locally (35/35 in 0.31 s)
- [ ] CI green on Python 3.9 – 3.12 once the workflow runs

https://claude.ai/code/session_01LXNujqFbLxqwo9xgNdkfPP

---
_Generated by [Claude Code](https://claude.ai/code/session_01LXNujqFbLxqwo9xgNdkfPP)_