### PR TITLE
Add calc.py one-shot CLI

### DIFF
--- a/calc.py
+++ b/calc.py
@@ -1,0 +1,26 @@
+"""Compact CLI calculator: evaluate one expression and print the result.
+
+    $ python calc.py "2 + 3 * (4 - 1)"
+    11
+
+Supports + - * / // % ** parentheses, and sqrt/abs functions. Pure stdlib.
+"""
+
+import sys
+
+from calculator import _format, evaluate
+
+
+def main(argv):
+    if len(argv) < 2:
+        print("usage: calc.py <expression>", file=sys.stderr)
+        sys.exit(2)
+    try:
+        print(_format(evaluate(" ".join(argv[1:]))))
+    except ValueError as e:
+        print(f"error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main(sys.argv)


### PR DESCRIPTION
## Summary
- Adds `calc.py`, a tiny one-shot CLI that evaluates a single arithmetic expression passed via argv and prints the result.
- Reuses `calculator.evaluate` and `_format` so parsing/evaluation logic stays in one place.

## Test plan
- [x] `python calc.py "2 + 3 * (4 - 1)"` → `11`
- [x] `python calc.py "sqrt(16) + 2**3"` → `12`
- [x] `python calc.py "10 / 0"` → prints `error: division by zero` and exits 1
- [x] `python calc.py` (no args) → prints usage and exits 2


---
_Generated by [Claude Code](https://claude.ai/code/session_01Px2HDby1B6fFmNarQSvBNb)_