### PR TITLE
Add floor division to simple calculator

### DIFF
--- a/simple_calculator.py
+++ b/simple_calculator.py
@@ -33,6 +33,13 @@ class Calculator:
         self._record("divide", a, b, result)
         return result
 
+    def floor_divide(self, a, b):
+        if b == 0:
+            raise ValueError("division by zero")
+        result = a // b
+        self._record("floor_divide", a, b, result)
+        return result
+
     def power(self, a, b):
         result = a ** b
         self._record("power", a, b, result)
@@ -66,6 +73,7 @@ def main():
     ops = {
         "+": calc.add, "-": calc.subtract,
         "*": calc.multiply, "/": calc.divide,
+        "//": calc.floor_divide,
         "**": calc.power, "%": calc.modulo,
     }
     print("Simple Calculator — enter '<a> <op> <b>' (e.g. '3 + 4'), or 'quit'.")

--- a/test_simple_calculator.py
+++ b/test_simple_calculator.py
@@ -1,0 +1,53 @@
+"""
+Tests for simple_calculator.Calculator.
+
+Run:
+    python -m unittest test_simple_calculator
+"""
+
+import unittest
+
+from simple_calculator import Calculator
+
+
+class CalculatorTests(unittest.TestCase):
+    def setUp(self):
+        self.calc = Calculator()
+
+    def test_basic_operations(self):
+        self.assertEqual(self.calc.add(2, 3), 5)
+        self.assertEqual(self.calc.subtract(10, 4), 6)
+        self.assertEqual(self.calc.multiply(6, 7), 42)
+        self.assertEqual(self.calc.divide(20, 4), 5)
+        self.assertEqual(self.calc.power(2, 8), 256)
+        self.assertEqual(self.calc.modulo(10, 3), 1)
+
+    def test_floor_divide(self):
+        self.assertEqual(self.calc.floor_divide(10, 3), 3)
+        self.assertEqual(self.calc.floor_divide(7, 2), 3)
+        self.assertEqual(self.calc.floor_divide(-7, 2), -4)
+
+    def test_floor_divide_by_zero_raises(self):
+        with self.assertRaises(ValueError):
+            self.calc.floor_divide(1, 0)
+
+    def test_divide_by_zero_raises(self):
+        with self.assertRaises(ValueError):
+            self.calc.divide(1, 0)
+
+    def test_history_records_operations(self):
+        self.calc.add(1, 2)
+        self.calc.floor_divide(9, 2)
+        self.assertEqual(len(self.calc.history), 2)
+        self.assertEqual(self.calc.history[-1],
+                         {"op": "floor_divide", "a": 9, "b": 2, "result": 4})
+
+    def test_memory_register(self):
+        self.calc.store(42)
+        self.assertEqual(self.calc.recall(), 42)
+        self.calc.clear_memory()
+        self.assertEqual(self.calc.recall(), 0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Adds floor-division support to the class-based `simple_calculator.py` and introduces a test module for it.

## Changes

- Add a `floor_divide(a, b)` method to `Calculator` (raises `ValueError` on division by zero, records to history like the other operations).
- Wire the `//` operator into the interactive REPL's operator map.
- Add `test_simple_calculator.py` covering basic arithmetic, floor division, error handling, history recording, and the memory register.

## Testing

```
python -m unittest test_simple_calculator -v   # 6 tests, all passing
```

This change is independent of the README compression-docs PR and touches a disjoint set of files.

https://claude.ai/code/session_01H1ZxowgwUSuezocyy1AyN8

---
_Generated by [Claude Code](https://claude.ai/code/session_01H1ZxowgwUSuezocyy1AyN8)_