### PR TITLE
Add numeric input validation to Calculator methods

### DIFF
--- a/simple_calculator.py
+++ b/simple_calculator.py
@@ -6,27 +6,45 @@ Pure standard library.
 """
 
 
+def _as_number(name, value):
+    """Validate that ``value`` is a real number and return it.
+
+    Rejects ``bool`` (a subclass of ``int``) and any non-numeric type so
+    that arithmetic methods never silently fall back to string/sequence
+    behaviour (e.g. ``"a" + "b"`` or ``"x" * 3``).
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TypeError(
+            f"{name} must be an int or float, got {type(value).__name__}"
+        )
+    return value
+
+
 class Calculator:
     def __init__(self):
         self.memory = 0
         self.history = []
 
     def add(self, a, b):
+        a, b = _as_number("a", a), _as_number("b", b)
         result = a + b
         self._record("add", a, b, result)
         return result
 
     def subtract(self, a, b):
+        a, b = _as_number("a", a), _as_number("b", b)
         result = a - b
         self._record("subtract", a, b, result)
         return result
 
     def multiply(self, a, b):
+        a, b = _as_number("a", a), _as_number("b", b)
         result = a * b
         self._record("multiply", a, b, result)
         return result
 
     def divide(self, a, b):
+        a, b = _as_number("a", a), _as_number("b", b)
         if b == 0:
             raise ValueError("division by zero")
         result = a / b
@@ -34,11 +52,13 @@ class Calculator:
         return result
 
     def power(self, a, b):
+        a, b = _as_number("a", a), _as_number("b", b)
         result = a ** b
         self._record("power", a, b, result)
         return result
 
     def modulo(self, a, b):
+        a, b = _as_number("a", a), _as_number("b", b)
         if b == 0:
             raise ValueError("modulo by zero")
         result = a % b
@@ -46,7 +66,7 @@ class Calculator:
         return result
 
     def store(self, value):
-        self.memory = value
+        self.memory = _as_number("value", value)
 
     def recall(self):
         return self.memory

--- a/test_simple_calculator.py
+++ b/test_simple_calculator.py
@@ -1,0 +1,79 @@
+"""
+Tests for the class-based Calculator in simple_calculator.py.
+
+Run:
+    python -m unittest test_simple_calculator
+"""
+
+import unittest
+
+from simple_calculator import Calculator
+
+
+class ArithmeticTests(unittest.TestCase):
+    def setUp(self):
+        self.calc = Calculator()
+
+    def test_basic_operations(self):
+        self.assertEqual(self.calc.add(2, 3), 5)
+        self.assertEqual(self.calc.subtract(10, 4), 6)
+        self.assertEqual(self.calc.multiply(6, 7), 42)
+        self.assertEqual(self.calc.divide(20, 4), 5)
+        self.assertEqual(self.calc.power(2, 8), 256)
+        self.assertEqual(self.calc.modulo(10, 3), 1)
+
+    def test_divide_by_zero_raises(self):
+        with self.assertRaises(ValueError):
+            self.calc.divide(1, 0)
+
+    def test_modulo_by_zero_raises(self):
+        with self.assertRaises(ValueError):
+            self.calc.modulo(1, 0)
+
+
+class InputValidationTests(unittest.TestCase):
+    def setUp(self):
+        self.calc = Calculator()
+
+    BINARY_METHODS = ("add", "subtract", "multiply", "divide", "power", "modulo")
+
+    def test_string_arguments_rejected(self):
+        for name in self.BINARY_METHODS:
+            method = getattr(self.calc, name)
+            with self.subTest(method=name):
+                with self.assertRaises(TypeError):
+                    method("a", "b")
+
+    def test_non_numeric_types_rejected(self):
+        for bad in ("x", None, [1], {"a": 1}, (1,)):
+            with self.subTest(value=bad):
+                with self.assertRaises(TypeError):
+                    self.calc.add(bad, 1)
+                with self.assertRaises(TypeError):
+                    self.calc.add(1, bad)
+
+    def test_bool_rejected(self):
+        # bool is a subclass of int but is not a valid numeric operand here.
+        with self.assertRaises(TypeError):
+            self.calc.add(True, 1)
+        with self.assertRaises(TypeError):
+            self.calc.multiply(1, False)
+
+    def test_float_and_int_accepted(self):
+        self.assertAlmostEqual(self.calc.add(1.5, 2), 3.5)
+        self.assertAlmostEqual(self.calc.multiply(2.0, 3.0), 6.0)
+
+    def test_store_validates_input(self):
+        with self.assertRaises(TypeError):
+            self.calc.store("not a number")
+        self.calc.store(42)
+        self.assertEqual(self.calc.recall(), 42)
+
+    def test_validation_failure_does_not_record_history(self):
+        with self.assertRaises(TypeError):
+            self.calc.add("a", "b")
+        self.assertEqual(self.calc.history, [])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

The class-based `Calculator` in `simple_calculator.py` accepted arguments of any type, so non-numeric input silently fell back to Python's string/sequence semantics:

- `add("a", "b")` returned `"ab"`
- `multiply("x", 3)` returned `"xxx"`
- `store("oops")` stored a string into the memory register

This adds input validation so arithmetic only ever runs on real numbers.

## Changes

- New `_as_number(name, value)` helper validates each operand is an `int` or `float` and raises `TypeError` otherwise.
- `bool` is explicitly rejected (it's an `int` subclass but not a meaningful numeric operand here).
- All binary methods (`add`, `subtract`, `multiply`, `divide`, `power`, `modulo`) and `store()` validate before doing any work, so a failed call does **not** pollute the operation history.
- The interactive `main()` REPL is unaffected — it already parses input via `float()`.

## Tests

Adds `test_simple_calculator.py` covering basic arithmetic, divide/modulo-by-zero, rejection of strings/None/containers/bool, acceptance of int/float, `store()` validation, and that validation failures leave history untouched.

All tests pass (`python -m unittest test_simple_calculator test_calculator`).

https://claude.ai/code/session_013m8qpbRzEPwUB6yyfHdPpD

---
_Generated by [Claude Code](https://claude.ai/code/session_013m8qpbRzEPwUB6yyfHdPpD)_