### PR TITLE
Handle arithmetic overflow gracefully in calculator

### DIFF
--- a/calculator.py
+++ b/calculator.py
@@ -142,6 +142,8 @@ def eval_rpn(rpn):
                 stack.append(BINARY_OPS[value](a, b))
             except ZeroDivisionError:
                 raise ValueError("division by zero")
+            except OverflowError:
+                raise ValueError("numeric overflow")
     if len(stack) != 1:
         raise ValueError("invalid expression")
     return stack[0]

--- a/test_calculator.py
+++ b/test_calculator.py
@@ -33,5 +33,21 @@ class BasicArithmeticTests(unittest.TestCase):
                 self.assertAlmostEqual(evaluate(expr), expected, places=9)
 
 
+class ErrorHandlingTests(unittest.TestCase):
+    # Arithmetic errors should surface as ValueError with a clean message
+    # rather than crashing with an unhandled traceback.
+    error_cases = [
+        ("10 / 0",     "division by zero"),
+        ("2 ** 10000", "numeric overflow"),
+    ]
+
+    def test_arithmetic_errors_raise_valueerror(self):
+        for expr, message in self.error_cases:
+            with self.subTest(expr=expr):
+                with self.assertRaises(ValueError) as ctx:
+                    evaluate(expr)
+                self.assertEqual(str(ctx.exception), message)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

While searching the codebase for `TODO`/`FIXME` comments to implement, I found **none** — the code is fully implemented. Instead, I looked for genuinely incomplete/fragile behavior and fixed a real latent bug in `calculator.py`.

`eval_rpn` only guarded `ZeroDivisionError` when evaluating binary operators, so expressions that overflow Python's `float` arithmetic crashed the REPL/CLI with an unhandled `OverflowError` traceback instead of the clean `error: ...` message used everywhere else.

### Before
```
$ python calculator.py "2 ** 10000"
Traceback (most recent call last):
  ...
OverflowError: (34, 'Numerical result out of range')
```

### After
```
$ python calculator.py "2 ** 10000"
error: numeric overflow
```

## Changes
- `calculator.py`: convert `OverflowError` into a clean `ValueError("numeric overflow")` so it flows through the existing error-reporting path (matching how `division by zero` is handled).
- `test_calculator.py`: add `ErrorHandlingTests` covering both the division-by-zero and overflow cases.

## Testing
- `python -m unittest test_calculator -v` — passes
- `python -m unittest discover -s tests -v` — all 35 tests pass

https://claude.ai/code/session_012GecnBfYZcLqunygKWywkH

---
_Generated by [Claude Code](https://claude.ai/code/session_012GecnBfYZcLqunygKWywkH)_