### PR TITLE
Add prioritized project to-do plan

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,66 @@
+# Project To-Do Plan
+
+A prioritized plan for MicTest12. The repo currently holds several independent pieces: the
+Barber Booking Agent (the main app, with email templates and compression helpers), two
+calculators, a web scraper, an image-analysis CLI, static HTML pages, and a gaming-platform
+microservices plan document. The plan below is ordered so that correctness and CI gaps are
+closed first, then the codebase is organized, then features are extended.
+
+## Phase 1 — Fix CI and test gaps (highest priority)
+
+- [ ] **Run all tests in CI.** `.github/workflows/tests.yml` runs
+      `python -m unittest discover -s tests`, which misses the root-level
+      `test_calculator.py` (5 tests) and `test_compression.py` (2 tests). Either move both
+      files into `tests/` (preferred, one convention) or change the workflow to also
+      discover from the repo root.
+- [ ] **Add missing test coverage.** `web_scraper.py`, `email_template.py`, and
+      `calculator.py`'s expression parser/REPL have no tests. Start with pure functions
+      (HTML parsing, template rendering, tokenizer) — they need no network or SMTP.
+- [ ] **Add a linter to CI.** A `ruff check` (or `flake8`) step catches drift cheaply across
+      Python versions already in the matrix.
+
+## Phase 2 — Organize the repository
+
+- [ ] **Decide the repo's identity.** The README describes only the booking agent and the
+      image analyzer, but half the files are unrelated demos. Either scope the repo to the
+      booking agent and move demos to an `examples/` folder, or restructure into per-tool
+      directories (`booking/`, `calculator/`, `scraper/`, `web/`).
+- [ ] **Consolidate the two calculators.** `calculator.py` (expression REPL) and
+      `simple_calculator.py` (class-based with memory/history) overlap; merge into one
+      module with both interfaces, or document why both exist.
+- [ ] **Update the README** to cover everything that ships: calculators, compression
+      helpers, web scraper, email templates, the HTML pages, and a pointer to
+      `GAMING_MICROSERVICES_PLAN.md`.
+- [ ] **Clean up `page.html`** (an 11-line stub) — either grow it into a real page linked
+      from `index.html`/`about.html` or delete it.
+
+## Phase 3 — Booking agent improvements (the core app)
+
+- [ ] **Wire compression into the agent.** `compression.py` says it exists "for the Barber
+      Booking Agent," but `barber_booking_agent.py` never imports it. Use it to archive old
+      `bookings.json` data, or move it to a generic utilities area.
+- [ ] **Use the HTML email templates end-to-end.** Verify `email_template.py` renders are
+      actually sent as multipart (text + HTML) by the agent's SMTP path, with a test using
+      mocked SMTP.
+- [ ] **Harden persistence.** Guard `bookings.json` reads against corruption (bad JSON →
+      backup + fresh start rather than crash), and write atomically (temp file + rename).
+- [ ] **Add non-interactive CLI flags** (e.g. `--list`, `--book ...`) so the agent is
+      scriptable and testable beyond the interactive menu.
+
+## Phase 4 — Stretch / product direction
+
+- [ ] **Decide the fate of the gaming microservices plan.** It's a design doc unrelated to
+      the code. Answer its own "Open Questions" section and start Phase 0 in a separate
+      repo, or park it under `docs/`.
+- [ ] **Web front-end for bookings.** `index.html`/`about.html` are static; a small
+      stdlib `http.server`-based UI over the booking agent would tie the HTML and Python
+      halves of the repo together.
+- [ ] **Scraper output → analysis.** Add an example notebook or script that consumes the
+      scraper's JSON/CSV output, since the scraper advertises "analysis-ready" records.
+
+## Suggested order of attack
+
+1. Phase 1 items — small, mechanical, immediately raise confidence in every later change.
+2. The repo-identity decision in Phase 2 — it determines where everything else lands.
+3. Phase 3 top-to-bottom — each item is independently shippable.
+4. Phase 4 only after the above, and only the items that match where the project is headed.

--- a/even_sum.py
+++ b/even_sum.py
@@ -8,7 +8,17 @@ def sum_even_numbers(numbers):
 
     Odd numbers are ignored. An empty list (or one with no even
     numbers) sums to 0.
+
+    Every element must be an integer; a non-integer value (including
+    bool, float, str, None, ...) raises TypeError naming the offending
+    value and its position.
     """
+    for i, n in enumerate(numbers):
+        if not isinstance(n, int) or isinstance(n, bool):
+            raise TypeError(
+                "sum_even_numbers expects integers, got "
+                f"{type(n).__name__} {n!r} at index {i}"
+            )
     return sum(n for n in numbers if n % 2 == 0)
 
 

--- a/even_sum.py
+++ b/even_sum.py
@@ -1,0 +1,16 @@
+"""
+Sum the even numbers in a list. Pure standard library.
+"""
+
+
+def sum_even_numbers(numbers):
+    """Return the sum of the even numbers in `numbers`.
+
+    Odd numbers are ignored. An empty list (or one with no even
+    numbers) sums to 0.
+    """
+    return sum(n for n in numbers if n % 2 == 0)
+
+
+if __name__ == "__main__":
+    print(sum_even_numbers([1, 2, 3, 4, 5, 6]))  # 12

--- a/tests/test_even_sum.py
+++ b/tests/test_even_sum.py
@@ -1,0 +1,27 @@
+import unittest
+
+from even_sum import sum_even_numbers
+
+
+class TestSumEvenNumbers(unittest.TestCase):
+    def test_mixed_numbers(self):
+        self.assertEqual(sum_even_numbers([1, 2, 3, 4, 5, 6]), 12)
+
+    def test_empty_list(self):
+        self.assertEqual(sum_even_numbers([]), 0)
+
+    def test_no_evens(self):
+        self.assertEqual(sum_even_numbers([1, 3, 5]), 0)
+
+    def test_all_evens(self):
+        self.assertEqual(sum_even_numbers([2, 4, 6]), 12)
+
+    def test_negative_numbers(self):
+        self.assertEqual(sum_even_numbers([-2, -3, 4]), 2)
+
+    def test_zero_counts_as_even(self):
+        self.assertEqual(sum_even_numbers([0, 1, 2]), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_even_sum.py
+++ b/tests/test_even_sum.py
@@ -22,6 +22,23 @@ class TestSumEvenNumbers(unittest.TestCase):
     def test_zero_counts_as_even(self):
         self.assertEqual(sum_even_numbers([0, 1, 2]), 2)
 
+    def test_float_raises_type_error(self):
+        with self.assertRaises(TypeError) as ctx:
+            sum_even_numbers([1, 2.5, 3])
+        self.assertIn("index 1", str(ctx.exception))
+
+    def test_string_raises_type_error(self):
+        with self.assertRaises(TypeError):
+            sum_even_numbers([2, "4"])
+
+    def test_none_raises_type_error(self):
+        with self.assertRaises(TypeError):
+            sum_even_numbers([None])
+
+    def test_bool_raises_type_error(self):
+        with self.assertRaises(TypeError):
+            sum_even_numbers([True, 2])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Adds `TODO.md`, a prioritized to-do plan for the project based on the current state of the repository, plus a small `sum_even_numbers` helper requested afterwards.

## What's in the plan

- **Phase 1 — CI and test gaps:** CI's `unittest discover -s tests` misses the root-level `test_calculator.py` and `test_compression.py` (7 tests that only run locally); missing coverage for `web_scraper.py`, `email_template.py`, and the `calculator.py` parser; add a lint step.
- **Phase 2 — Repo organization:** decide the repo's scope (booking agent vs. mixed demos), consolidate the two calculators, update the README to cover everything shipped, clean up the `page.html` stub.
- **Phase 3 — Booking agent improvements:** actually wire in `compression.py` and the HTML email templates, harden `bookings.json` persistence, add non-interactive CLI flags.
- **Phase 4 — Stretch:** decide the fate of `GAMING_MICROSERVICES_PLAN.md`, a small web UI over the booking agent, scraper output analysis examples.

## Code changes

- `even_sum.py`: `sum_even_numbers(numbers)` returns the sum of the even numbers in a list (stdlib only, matching the repo's conventions). Input is validated: non-integer values (including bool, float, str, None) raise `TypeError` naming the offending value and its index.
- `tests/test_even_sum.py`: 10 unit tests covering mixed/empty/no-even/all-even lists, negatives, zero, and TypeError cases for float, str, None, and bool inputs. Placed in `tests/` so CI picks them up.

All 45 tests in `tests/` pass locally, plus the 7 root-level tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CwX9LXkGrLDyY2VMTWB2qb