### PR TITLE
Add simple portfolio webpage

### DIFF
--- a/PORTFOLIO_OVERVIEW.md
+++ b/PORTFOLIO_OVERVIEW.md
@@ -1,0 +1,68 @@
+# Portfolio Webpage — Project Overview
+
+A simple, self-contained portfolio site built as a single HTML file with no
+external dependencies. This document describes what the page contains, how it
+is structured, and how to work with it.
+
+## Project Summary
+
+`portfolio.html` is a single-page personal portfolio for a fictional developer
+("Jane Doe"). It demonstrates the core building blocks of a static webpage:
+semantic headings, a sticky navigation bar, embedded images, a responsive
+project grid, and a contact form with built-in HTML5 validation. All styling
+lives in an inline `<style>` block and all images are inline SVG data URIs, so
+the page renders correctly offline — just open the file in a browser.
+
+## Features
+
+- **Navigation**
+  - Sticky top bar that stays visible while scrolling
+  - Anchor links to each section:
+    - Home
+    - About
+    - Projects
+    - Contact
+- **Content sections**
+  - Hero with an `h1` heading and subtitle
+  - About section with a circular profile image
+  - Projects grid with three cards, each containing:
+    - A thumbnail image
+    - A title and short description
+- **Contact form**
+  - Labeled fields:
+    - Name (required)
+    - Email (required, validated as an email address)
+    - Subject (optional)
+    - Message (required)
+  - Submit button with hover styling
+
+## Page Structure
+
+| Section  | Anchor      | Key elements                                  |
+| -------- | ----------- | --------------------------------------------- |
+| Home     | `#home`     | `h1` heading, subtitle                        |
+| About    | `#about`    | Profile image, bio paragraph                  |
+| Projects | `#projects` | CSS grid of three project cards               |
+| Contact  | `#contact`  | Form with name, email, subject, message       |
+| Footer   | —           | Copyright notice                              |
+
+## Usage
+
+No build step or server is required. Open the file directly:
+
+```bash
+# From the repository root
+open portfolio.html        # macOS
+xdg-open portfolio.html    # Linux
+
+# Or serve it locally if you prefer
+python3 -m http.server 8000
+# then visit http://localhost:8000/portfolio.html
+```
+
+## Customization Notes
+
+Replace the "Jane Doe" placeholder name, bio text, and project descriptions
+with real content. The SVG data-URI images can be swapped for real photos by
+pointing each `src` at an image file, and the accent color can be changed by
+searching the stylesheet for `#c9b458`.

--- a/meeting_agenda.txt
+++ b/meeting_agenda.txt
@@ -1,0 +1,65 @@
+=====================================================================
+                    PORTFOLIO WEBSITE PROJECT
+                    Weekly Team Meeting Agenda
+=====================================================================
+
+Date:       Monday, July 20, 2026
+Time:       10:00 AM - 11:00 AM
+Location:   Conference Room B / Video call
+Attendees:  Jane Doe (lead), Alex Kim (design), Priya Patel (dev),
+            Sam Rivera (content)
+
+---------------------------------------------------------------------
+AGENDA
+---------------------------------------------------------------------
+
+1. Welcome and review of last week's action items       (5 min)
+
+2. Portfolio page status update                         (10 min)
+   - Draft page merged review: navigation, images, contact form
+   - Feedback collected from stakeholders
+
+3. Content review                                       (15 min)
+   - Replace placeholder "Jane Doe" bio with final copy
+   - Select real project screenshots to replace SVG placeholders
+
+4. Design polish                                        (15 min)
+   - Accent color and typography decisions
+   - Mobile layout walkthrough
+
+5. Contact form backend                                 (10 min)
+   - Options: hosted form service vs. simple mail handler
+   - Spam protection approach
+
+6. Open floor / questions                               (5 min)
+
+---------------------------------------------------------------------
+ACTION ITEMS AND DEADLINES
+---------------------------------------------------------------------
+
+[ ] Finalize bio and project descriptions
+    Owner:    Sam Rivera
+    Deadline: Wednesday, July 22, 2026
+
+[ ] Deliver three project screenshots (400x220, optimized)
+    Owner:    Alex Kim
+    Deadline: Friday, July 24, 2026
+
+[ ] Evaluate form backend options and recommend one
+    Owner:    Priya Patel
+    Deadline: Friday, July 24, 2026
+
+[ ] Complete mobile layout QA pass (phones and tablets)
+    Owner:    Priya Patel
+    Deadline: Monday, July 27, 2026
+
+[ ] Circulate final copy deck for sign-off
+    Owner:    Jane Doe
+    Deadline: Tuesday, July 28, 2026
+
+---------------------------------------------------------------------
+NEXT MEETING
+---------------------------------------------------------------------
+
+Monday, July 27, 2026, 10:00 AM - Conference Room B
+Please review the action items above before attending.

--- a/portfolio.html
+++ b/portfolio.html
@@ -1,0 +1,274 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Jane Doe — Portfolio</title>
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: Georgia, 'Times New Roman', serif;
+      line-height: 1.6;
+      color: #2b2b2b;
+      background-color: #faf8f5;
+    }
+
+    /* Navigation */
+    nav {
+      position: sticky;
+      top: 0;
+      background-color: #2b2b2b;
+      padding: 1rem 2rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      z-index: 10;
+    }
+
+    nav .logo {
+      color: #faf8f5;
+      font-size: 1.25rem;
+      font-weight: bold;
+      letter-spacing: 0.05em;
+    }
+
+    nav ul {
+      list-style: none;
+      display: flex;
+      gap: 1.5rem;
+    }
+
+    nav a {
+      color: #faf8f5;
+      text-decoration: none;
+      font-size: 0.95rem;
+    }
+
+    nav a:hover {
+      text-decoration: underline;
+      text-underline-offset: 4px;
+    }
+
+    /* Layout */
+    section {
+      max-width: 960px;
+      margin: 0 auto;
+      padding: 4rem 2rem;
+    }
+
+    h1 {
+      font-size: 2.75rem;
+      margin-bottom: 0.5rem;
+    }
+
+    h2 {
+      font-size: 2rem;
+      margin-bottom: 1.5rem;
+      border-bottom: 2px solid #c9b458;
+      display: inline-block;
+      padding-bottom: 0.25rem;
+    }
+
+    h3 {
+      font-size: 1.25rem;
+      margin-bottom: 0.5rem;
+    }
+
+    .subtitle {
+      font-size: 1.25rem;
+      color: #6b6b6b;
+      font-style: italic;
+    }
+
+    /* About */
+    #about .about-wrap {
+      display: flex;
+      gap: 2rem;
+      align-items: center;
+      flex-wrap: wrap;
+      margin-top: 1.5rem;
+    }
+
+    #about img {
+      border-radius: 50%;
+      width: 180px;
+      height: 180px;
+    }
+
+    #about p {
+      flex: 1;
+      min-width: 260px;
+    }
+
+    /* Projects */
+    .projects-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 2rem;
+    }
+
+    .project-card {
+      background-color: #ffffff;
+      border: 1px solid #e3ded6;
+      border-radius: 8px;
+      overflow: hidden;
+    }
+
+    .project-card img {
+      width: 100%;
+      height: auto;
+      display: block;
+    }
+
+    .project-card .card-body {
+      padding: 1.25rem;
+    }
+
+    /* Contact form */
+    form {
+      max-width: 540px;
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+      margin-top: 1rem;
+    }
+
+    label {
+      font-weight: bold;
+      font-size: 0.95rem;
+    }
+
+    input, textarea {
+      font: inherit;
+      padding: 0.6rem;
+      border: 1px solid #c4bdb2;
+      border-radius: 4px;
+      background-color: #ffffff;
+      width: 100%;
+    }
+
+    input:focus, textarea:focus {
+      outline: 2px solid #c9b458;
+      border-color: transparent;
+    }
+
+    button {
+      font: inherit;
+      align-self: flex-start;
+      background-color: #2b2b2b;
+      color: #faf8f5;
+      border: none;
+      border-radius: 4px;
+      padding: 0.75rem 2rem;
+      cursor: pointer;
+    }
+
+    button:hover {
+      background-color: #c9b458;
+      color: #2b2b2b;
+    }
+
+    footer {
+      text-align: center;
+      padding: 2rem;
+      background-color: #2b2b2b;
+      color: #faf8f5;
+      font-size: 0.9rem;
+    }
+  </style>
+</head>
+<body>
+
+  <nav>
+    <span class="logo">Jane Doe</span>
+    <ul>
+      <li><a href="#home">Home</a></li>
+      <li><a href="#about">About</a></li>
+      <li><a href="#projects">Projects</a></li>
+      <li><a href="#contact">Contact</a></li>
+    </ul>
+  </nav>
+
+  <section id="home">
+    <h1>Hello, I'm Jane Doe</h1>
+    <p class="subtitle">Web developer &amp; designer crafting clean, useful things for the web.</p>
+  </section>
+
+  <section id="about">
+    <h2>About Me</h2>
+    <div class="about-wrap">
+      <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180'%3E%3Crect width='180' height='180' fill='%23c9b458'/%3E%3Ccircle cx='90' cy='68' r='30' fill='%23faf8f5'/%3E%3Cellipse cx='90' cy='150' rx='52' ry='40' fill='%23faf8f5'/%3E%3C/svg%3E" alt="Portrait of Jane Doe">
+      <p>
+        I'm a developer with a passion for building simple, accessible websites.
+        I enjoy turning ideas into working products, from the first sketch to the
+        final deploy. When I'm not coding, you'll find me sketching interfaces,
+        reading about typography, or hiking with my dog.
+      </p>
+    </div>
+  </section>
+
+  <section id="projects">
+    <h2>Projects</h2>
+    <div class="projects-grid">
+      <article class="project-card">
+        <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='220'%3E%3Crect width='400' height='220' fill='%234a6fa5'/%3E%3Ctext x='200' y='118' font-family='Georgia' font-size='24' fill='%23ffffff' text-anchor='middle'%3EWeather App%3C/text%3E%3C/svg%3E" alt="Screenshot of the weather application">
+        <div class="card-body">
+          <h3>Weather App</h3>
+          <p>A lightweight app showing live forecasts with a clean, glanceable layout.</p>
+        </div>
+      </article>
+
+      <article class="project-card">
+        <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='220'%3E%3Crect width='400' height='220' fill='%236a8f5f'/%3E%3Ctext x='200' y='118' font-family='Georgia' font-size='24' fill='%23ffffff' text-anchor='middle'%3ERecipe Finder%3C/text%3E%3C/svg%3E" alt="Screenshot of the recipe finder website">
+        <div class="card-body">
+          <h3>Recipe Finder</h3>
+          <p>Search thousands of recipes by ingredient, cuisine, or cooking time.</p>
+        </div>
+      </article>
+
+      <article class="project-card">
+        <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='220'%3E%3Crect width='400' height='220' fill='%23a45a52'/%3E%3Ctext x='200' y='118' font-family='Georgia' font-size='24' fill='%23ffffff' text-anchor='middle'%3ETask Tracker%3C/text%3E%3C/svg%3E" alt="Screenshot of the task tracker tool">
+        <div class="card-body">
+          <h3>Task Tracker</h3>
+          <p>A minimal to-do tool with drag-and-drop lists and offline support.</p>
+        </div>
+      </article>
+    </div>
+  </section>
+
+  <section id="contact">
+    <h2>Contact</h2>
+    <p>Have a project in mind? Send me a message and I'll get back to you.</p>
+    <form action="#" method="post">
+      <div>
+        <label for="name">Name</label>
+        <input type="text" id="name" name="name" placeholder="Your name" required>
+      </div>
+      <div>
+        <label for="email">Email</label>
+        <input type="email" id="email" name="email" placeholder="you@example.com" required>
+      </div>
+      <div>
+        <label for="subject">Subject</label>
+        <input type="text" id="subject" name="subject" placeholder="What's this about?">
+      </div>
+      <div>
+        <label for="message">Message</label>
+        <textarea id="message" name="message" rows="5" placeholder="Tell me about your project..." required></textarea>
+      </div>
+      <button type="submit">Send Message</button>
+    </form>
+  </section>
+
+  <footer>
+    <p>&copy; 2026 Jane Doe. All rights reserved.</p>
+  </footer>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds `portfolio.html`, a self-contained single-page portfolio site with:

- **Navigation** — a sticky top nav bar with anchor links to Home, About, Projects, and Contact sections
- **Headings** — an `h1` hero heading plus `h2`/`h3` section and project headings
- **Images** — a circular profile photo and three project card thumbnails, all embedded as inline SVG data URIs so the page has no external dependencies
- **Contact form** — name, email, subject, and message fields with labels, HTML5 validation (`required`, `type="email"`), and a submit button

All styling is inline CSS in the `<head>`; the layout is responsive via flexbox and a CSS grid that collapses on narrow screens.

## Test plan

- Open `portfolio.html` in a browser and verify the nav links scroll to each section
- Confirm the three project cards and profile image render without network access
- Submit the contact form empty to check the built-in validation triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RmrLF64szdp2diFPeQwjR4

---
_Generated by [Claude Code](https://claude.ai/code/session_01RmrLF64szdp2diFPeQwjR4)_