### PR TITLE
Add sum_even_numbers function with unit tests

### DIFF
--- a/sum_even_numbers.py
+++ b/sum_even_numbers.py
@@ -1,0 +1,45 @@
+"""
+Sum the even numbers in a list.
+
+Pure standard library.
+"""
+
+
+def sum_even_numbers(numbers):
+    """Return the sum of the even numbers in the given list.
+
+    Only integers (including bools' parent type, and floats with an
+    integral value) can be even; non-integral floats are skipped.
+    Returns 0 for an empty list or a list with no even numbers.
+    """
+    total = 0
+    for n in numbers:
+        if isinstance(n, float):
+            if not n.is_integer():
+                continue
+            n = int(n)
+        if isinstance(n, int) and n % 2 == 0:
+            total += n
+    return total
+
+
+def main():
+    print("Sum of even numbers — enter numbers separated by spaces, or 'quit'.")
+    while True:
+        try:
+            line = input("> ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return
+        if line in ("quit", "exit", ""):
+            return
+        try:
+            numbers = [float(part) for part in line.split()]
+        except ValueError:
+            print("error: expected numbers separated by spaces")
+            continue
+        print(sum_even_numbers(numbers))
+
+
+if __name__ == "__main__":
+    main()

--- a/sum_even_numbers.py
+++ b/sum_even_numbers.py
@@ -8,17 +8,28 @@ Pure standard library.
 def sum_even_numbers(numbers):
     """Return the sum of the even numbers in the given list.
 
-    Only integers (including bools' parent type, and floats with an
-    integral value) can be even; non-integral floats are skipped.
-    Returns 0 for an empty list or a list with no even numbers.
+    Floats with an integral value (e.g. 4.0) count as even; non-integral
+    floats are skipped. Returns 0 for an empty list or a list with no
+    even numbers.
+
+    Raises TypeError if numbers is not a list, or if it contains a
+    non-numeric value (str, None, bool, ...).
     """
+    if not isinstance(numbers, list):
+        raise TypeError(
+            f"expected a list of numbers, got {type(numbers).__name__}"
+        )
     total = 0
-    for n in numbers:
+    for i, n in enumerate(numbers):
+        if isinstance(n, bool) or not isinstance(n, (int, float)):
+            raise TypeError(
+                f"element at index {i} is not a number: {n!r}"
+            )
         if isinstance(n, float):
             if not n.is_integer():
                 continue
             n = int(n)
-        if isinstance(n, int) and n % 2 == 0:
+        if n % 2 == 0:
             total += n
     return total
 

--- a/tests/test_sum_even_numbers.py
+++ b/tests/test_sum_even_numbers.py
@@ -28,6 +28,26 @@ class TestSumEvenNumbers(unittest.TestCase):
     def test_non_integral_floats_skipped(self):
         self.assertEqual(sum_even_numbers([2.5, 4, 1.5]), 4)
 
+    def test_string_element_raises_type_error(self):
+        with self.assertRaises(TypeError):
+            sum_even_numbers([1, 2, "3"])
+
+    def test_none_element_raises_type_error(self):
+        with self.assertRaises(TypeError):
+            sum_even_numbers([2, None])
+
+    def test_bool_element_raises_type_error(self):
+        with self.assertRaises(TypeError):
+            sum_even_numbers([2, True])
+
+    def test_non_list_input_raises_type_error(self):
+        with self.assertRaises(TypeError):
+            sum_even_numbers("123")
+
+    def test_error_message_names_offending_index(self):
+        with self.assertRaisesRegex(TypeError, "index 1.*'x'"):
+            sum_even_numbers([2, "x", 4])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_sum_even_numbers.py
+++ b/tests/test_sum_even_numbers.py
@@ -1,0 +1,33 @@
+import unittest
+
+from sum_even_numbers import sum_even_numbers
+
+
+class TestSumEvenNumbers(unittest.TestCase):
+    def test_mixed_numbers(self):
+        self.assertEqual(sum_even_numbers([1, 2, 3, 4, 5, 6]), 12)
+
+    def test_all_even(self):
+        self.assertEqual(sum_even_numbers([2, 4, 6, 8]), 20)
+
+    def test_all_odd(self):
+        self.assertEqual(sum_even_numbers([1, 3, 5, 7]), 0)
+
+    def test_empty_list(self):
+        self.assertEqual(sum_even_numbers([]), 0)
+
+    def test_negative_numbers(self):
+        self.assertEqual(sum_even_numbers([-2, -3, -4, 5]), -6)
+
+    def test_zero_is_even(self):
+        self.assertEqual(sum_even_numbers([0, 1, 2]), 2)
+
+    def test_integral_floats_counted(self):
+        self.assertEqual(sum_even_numbers([2.0, 3.0, 4.0]), 6)
+
+    def test_non_integral_floats_skipped(self):
+        self.assertEqual(sum_even_numbers([2.5, 4, 1.5]), 4)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds `sum_even_numbers.py` with a `sum_even_numbers(numbers)` function that returns the sum of only the even numbers in a list. Negative even numbers and zero are included; floats with an integral value (e.g. `4.0`) count as even, while non-integral floats are skipped.
- Validates its input: raises `TypeError` when the argument is not a list, or when an element is non-numeric (`str`, `None`, `bool`, ...), with an error message naming the offending index and value.
- Includes a small interactive CLI (`python sum_even_numbers.py`) in the same style as the repo's other scripts.
- Adds `tests/test_sum_even_numbers.py` with 13 unittest cases covering mixed lists, all-even, all-odd, empty lists, negatives, zero, float handling, and the validation errors.

## Testing

```
python -m unittest tests.test_sum_even_numbers -v
Ran 13 tests in 0.001s — OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LdyDmiNN41XVPdS7wkYxKo