### PR TITLE
Add Paula's baby shop landing page

### DIFF
--- a/paula-baby-shop.html
+++ b/paula-baby-shop.html
@@ -1,0 +1,508 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="Paula's — a neighbourhood baby shop with organic textiles, heirloom wooden toys, and calm nursery pieces.">
+<title>Paula's — Little Things for Little Ones</title>
+<style>
+  :root {
+    --paper: #FBF8F3;
+    --paper-2: #F4EEE4;
+    --card: #FFFFFF;
+    --ink: #33404D;
+    --ink-soft: #5C6875;
+    --sky: #7EA8C9;
+    --sky-deep: #3F6C8C;
+    --clementine: #EFA45C;
+    --clementine-deep: #D9843A;
+    --blush: #E7B0A3;
+    --sage: #A6BF9C;
+    --line: #E7DFD2;
+    --shadow: 24px 30px 60px -30px rgba(63, 108, 140, .35);
+    --shadow-sm: 10px 14px 30px -18px rgba(63, 108, 140, .4);
+    --r-lg: 34px;
+    --r-md: 22px;
+    --r-sm: 14px;
+    --fs-display: clamp(2.9rem, 7vw, 5.4rem);
+    --fs-h2: clamp(1.9rem, 4vw, 2.9rem);
+    --fs-h3: 1.3rem;
+    --display: "SF Pro Rounded", ui-rounded, "Nunito", "Segoe UI", system-ui, sans-serif;
+    --body: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --paper: #1B2531;
+      --paper-2: #212D3B;
+      --card: #26333F;
+      --ink: #EAF1F6;
+      --ink-soft: #A9BBC8;
+      --sky: #8FBBDD;
+      --sky-deep: #A9CDE7;
+      --clementine: #F2B06B;
+      --clementine-deep: #F2B06B;
+      --blush: #E9B6AA;
+      --sage: #B4CDAA;
+      --line: #34434F;
+      --shadow: 24px 30px 60px -28px rgba(0, 0, 0, .55);
+      --shadow-sm: 10px 14px 30px -18px rgba(0, 0, 0, .5);
+    }
+  }
+  :root[data-theme="light"] {
+    --paper: #FBF8F3; --paper-2: #F4EEE4; --card: #FFFFFF;
+    --ink: #33404D; --ink-soft: #5C6875; --sky: #7EA8C9; --sky-deep: #3F6C8C;
+    --clementine: #EFA45C; --clementine-deep: #D9843A; --blush: #E7B0A3;
+    --sage: #A6BF9C; --line: #E7DFD2;
+    --shadow: 24px 30px 60px -30px rgba(63,108,140,.35);
+    --shadow-sm: 10px 14px 30px -18px rgba(63,108,140,.4);
+  }
+  :root[data-theme="dark"] {
+    --paper: #1B2531; --paper-2: #212D3B; --card: #26333F;
+    --ink: #EAF1F6; --ink-soft: #A9BBC8; --sky: #8FBBDD; --sky-deep: #A9CDE7;
+    --clementine: #F2B06B; --clementine-deep: #F2B06B; --blush: #E9B6AA;
+    --sage: #B4CDAA; --line: #34434F;
+    --shadow: 24px 30px 60px -28px rgba(0,0,0,.55);
+    --shadow-sm: 10px 14px 30px -18px rgba(0,0,0,.5);
+  }
+
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    background: var(--paper);
+    color: var(--ink);
+    font-family: var(--body);
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+    overflow-x: hidden;
+  }
+  h1, h2, h3, .brand { font-family: var(--display); font-weight: 800; line-height: 1.05; letter-spacing: -.02em; text-wrap: balance; margin: 0; }
+  p { margin: 0; }
+  a { color: inherit; text-decoration: none; }
+  .wrap { width: min(1120px, 92vw); margin-inline: auto; }
+  .eyebrow {
+    font-size: .74rem; font-weight: 700; letter-spacing: .18em; text-transform: uppercase;
+    color: var(--sky-deep); display: inline-flex; align-items: center; gap: .5rem;
+  }
+  .eyebrow::before { content: ""; width: 26px; height: 2px; background: var(--clementine); border-radius: 2px; }
+
+  /* ---------- Nav ---------- */
+  header.nav {
+    position: sticky; top: 0; z-index: 40;
+    backdrop-filter: blur(10px);
+    background: color-mix(in srgb, var(--paper) 82%, transparent);
+    border-bottom: 1px solid var(--line);
+  }
+  .nav-in { display: flex; align-items: center; justify-content: space-between; padding: .85rem 0; }
+  .brand { display: flex; align-items: center; gap: .6rem; font-size: 1.4rem; color: var(--ink); }
+  .brand .mark {
+    width: 38px; height: 38px; border-radius: 50%;
+    background: radial-gradient(circle at 32% 30%, var(--clementine), var(--clementine-deep));
+    display: grid; place-items: center; box-shadow: var(--shadow-sm);
+  }
+  .brand .mark svg { width: 22px; height: 22px; }
+  .nav-links { display: flex; gap: 1.6rem; align-items: center; font-weight: 600; font-size: .95rem; color: var(--ink-soft); }
+  .nav-links a:hover { color: var(--sky-deep); }
+  .nav .btn { padding: .6rem 1.2rem; }
+  @media (max-width: 720px) { .nav-links a:not(.btn) { display: none; } }
+
+  .btn {
+    display: inline-flex; align-items: center; gap: .5rem;
+    background: var(--clementine); color: #3a2410; font-weight: 700;
+    padding: .85rem 1.5rem; border-radius: 999px; border: none; cursor: pointer;
+    box-shadow: var(--shadow-sm); transition: transform .18s ease, box-shadow .18s ease;
+    font-family: var(--display); font-size: 1rem;
+  }
+  .btn:hover { transform: translateY(-2px); box-shadow: 12px 18px 34px -16px rgba(217,132,58,.6); }
+  .btn.ghost { background: transparent; color: var(--sky-deep); box-shadow: none; border: 2px solid var(--sky); }
+  .btn.ghost:hover { background: color-mix(in srgb, var(--sky) 16%, transparent); }
+  :focus-visible { outline: 3px solid var(--sky-deep); outline-offset: 3px; border-radius: 6px; }
+
+  /* ---------- Hero ---------- */
+  .hero { position: relative; padding: clamp(3rem, 8vw, 6rem) 0 clamp(4rem, 9vw, 7rem); }
+  .hero-grid { display: grid; grid-template-columns: 1.05fr .95fr; gap: clamp(2rem, 5vw, 4rem); align-items: center; }
+  @media (max-width: 860px) { .hero-grid { grid-template-columns: 1fr; } }
+  .hero h1 { font-size: var(--fs-display); margin: 1.1rem 0 1.2rem; }
+  .hero h1 .swash { color: var(--sky-deep); font-style: italic; }
+  .hero p.lede { font-size: 1.18rem; color: var(--ink-soft); max-width: 42ch; }
+  .hero-cta { display: flex; gap: .9rem; flex-wrap: wrap; margin-top: 1.8rem; }
+  .trust { display: flex; gap: 1.6rem; margin-top: 2.4rem; flex-wrap: wrap; }
+  .trust div { display: flex; flex-direction: column; }
+  .trust .n { font-family: var(--display); font-weight: 800; font-size: 1.5rem; color: var(--ink); font-variant-numeric: tabular-nums; }
+  .trust .l { font-size: .82rem; color: var(--ink-soft); }
+
+  /* Cloud scene */
+  .scene {
+    position: relative; aspect-ratio: 1 / 1; border-radius: var(--r-lg);
+    background: linear-gradient(160deg, color-mix(in srgb, var(--sky) 55%, var(--paper)), color-mix(in srgb, var(--blush) 40%, var(--paper)));
+    box-shadow: var(--shadow); overflow: hidden;
+  }
+  .scene::after { content: ""; position: absolute; inset: 0; background: radial-gradient(circle at 70% 85%, rgba(255,255,255,.25), transparent 55%); }
+  .cloud { position: absolute; background: var(--card); border-radius: 999px; filter: drop-shadow(0 12px 20px rgba(63,108,140,.18)); }
+  .cloud::before, .cloud::after { content: ""; position: absolute; background: var(--card); border-radius: 50%; }
+  .c1 { width: 130px; height: 46px; top: 22%; left: 14%; animation: drift 9s ease-in-out infinite; }
+  .c1::before { width: 58px; height: 58px; top: -26px; left: 20px; }
+  .c1::after { width: 42px; height: 42px; top: -16px; left: 66px; }
+  .c2 { width: 96px; height: 34px; top: 60%; right: 12%; animation: drift 11s ease-in-out infinite reverse; }
+  .c2::before { width: 44px; height: 44px; top: -20px; left: 16px; }
+  .c2::after { width: 32px; height: 32px; top: -10px; left: 50px; }
+  .star { position: absolute; color: #fff; opacity: .9; animation: twinkle 4s ease-in-out infinite; }
+  .s1 { top: 16%; right: 22%; width: 26px; }
+  .s2 { bottom: 20%; left: 20%; width: 18px; animation-delay: 1.5s; }
+  .rattle {
+    position: absolute; top: 50%; left: 50%; width: 46%;
+    transform: translate(-50%, -50%) rotate(-8deg); transform-origin: 50% 78%;
+    animation: sway 5s ease-in-out infinite; filter: drop-shadow(0 18px 24px rgba(63,108,140,.28));
+  }
+  @keyframes drift { 0%,100% { transform: translateX(0); } 50% { transform: translateX(14px); } }
+  @keyframes sway { 0%,100% { transform: translate(-50%,-50%) rotate(-8deg); } 50% { transform: translate(-50%,-50%) rotate(6deg); } }
+  @keyframes twinkle { 0%,100% { opacity: .35; transform: scale(.85); } 50% { opacity: 1; transform: scale(1.1); } }
+
+  /* ---------- Section shells ---------- */
+  section { padding: clamp(3rem, 7vw, 5.5rem) 0; }
+  .sec-head { max-width: 52ch; margin-bottom: 2.6rem; }
+  .sec-head h2 { font-size: var(--fs-h2); margin: .8rem 0 .6rem; }
+  .sec-head p { color: var(--ink-soft); font-size: 1.05rem; }
+
+  /* Categories */
+  .cats { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1.1rem; }
+  @media (max-width: 820px) { .cats { grid-template-columns: repeat(2, 1fr); } }
+  .cat {
+    background: var(--card); border: 1px solid var(--line); border-radius: var(--r-md);
+    padding: 1.6rem 1.3rem; box-shadow: var(--shadow-sm); transition: transform .2s ease;
+    display: flex; flex-direction: column; gap: .7rem;
+  }
+  .cat:hover { transform: translateY(-5px); }
+  .cat .ic { width: 52px; height: 52px; border-radius: 16px; display: grid; place-items: center; }
+  .cat .ic svg { width: 28px; height: 28px; }
+  .cat:nth-child(1) .ic { background: color-mix(in srgb, var(--sky) 30%, var(--card)); color: var(--sky-deep); }
+  .cat:nth-child(2) .ic { background: color-mix(in srgb, var(--clementine) 30%, var(--card)); color: var(--clementine-deep); }
+  .cat:nth-child(3) .ic { background: color-mix(in srgb, var(--sage) 34%, var(--card)); color: #557048; }
+  .cat:nth-child(4) .ic { background: color-mix(in srgb, var(--blush) 34%, var(--card)); color: #b56b5b; }
+  .cat h3 { font-size: 1.12rem; }
+  .cat p { font-size: .9rem; color: var(--ink-soft); }
+
+  /* Products */
+  .grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1.4rem; }
+  @media (max-width: 900px) { .grid { grid-template-columns: repeat(2, 1fr); } }
+  @media (max-width: 560px) { .grid { grid-template-columns: 1fr; } }
+  .prod { background: var(--card); border: 1px solid var(--line); border-radius: var(--r-md); overflow: hidden; box-shadow: var(--shadow-sm); transition: transform .2s ease; }
+  .prod:hover { transform: translateY(-6px); }
+  .prod .ph { aspect-ratio: 4 / 3; position: relative; display: grid; place-items: center; }
+  .prod .ph svg { width: 46%; height: 46%; }
+  .prod .body { padding: 1.1rem 1.2rem 1.3rem; }
+  .prod .tag { font-size: .7rem; font-weight: 700; letter-spacing: .12em; text-transform: uppercase; color: var(--sky-deep); }
+  .prod h3 { font-size: 1.08rem; margin: .35rem 0 .5rem; }
+  .prod .row { display: flex; align-items: center; justify-content: space-between; margin-top: .8rem; }
+  .prod .price { font-family: var(--display); font-weight: 800; font-size: 1.25rem; font-variant-numeric: tabular-nums; }
+  .prod .add { border: none; background: color-mix(in srgb, var(--sky) 20%, var(--card)); color: var(--sky-deep); font-weight: 700; padding: .5rem .9rem; border-radius: 999px; cursor: pointer; font-family: var(--display); transition: background .18s ease; }
+  .prod .add:hover { background: var(--sky); color: #fff; }
+  .ribbon { position: absolute; top: .8rem; left: .8rem; background: var(--clementine); color: #3a2410; font-size: .68rem; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; padding: .3rem .7rem; border-radius: 999px; }
+
+  /* Values */
+  .values { background: var(--paper-2); border-radius: var(--r-lg); padding: clamp(2rem, 5vw, 3.5rem); }
+  .val-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1.6rem; }
+  @media (max-width: 780px) { .val-grid { grid-template-columns: 1fr; } }
+  .val { display: flex; gap: 1rem; }
+  .val .ic { flex: none; width: 46px; height: 46px; border-radius: 14px; display: grid; place-items: center; background: var(--card); color: var(--sky-deep); box-shadow: var(--shadow-sm); }
+  .val .ic svg { width: 24px; height: 24px; }
+  .val h3 { font-size: 1.06rem; margin-bottom: .25rem; }
+  .val p { font-size: .92rem; color: var(--ink-soft); }
+
+  /* Testimonial */
+  .quote { text-align: center; max-width: 60ch; margin-inline: auto; }
+  .quote .stars { color: var(--clementine); letter-spacing: .2em; font-size: 1.1rem; }
+  .quote blockquote { font-family: var(--display); font-weight: 700; font-size: clamp(1.4rem, 3.4vw, 2.1rem); line-height: 1.3; margin: 1rem 0 1.2rem; }
+  .quote cite { font-style: normal; color: var(--ink-soft); font-weight: 600; }
+
+  /* Newsletter */
+  .news {
+    background: linear-gradient(150deg, var(--sky-deep), color-mix(in srgb, var(--sky-deep) 60%, var(--blush)));
+    border-radius: var(--r-lg); padding: clamp(2.2rem, 5vw, 3.8rem); color: #fff; text-align: center;
+    box-shadow: var(--shadow); position: relative; overflow: hidden;
+  }
+  .news::before { content: ""; position: absolute; width: 220px; height: 220px; border-radius: 50%; background: rgba(255,255,255,.12); top: -80px; right: -40px; }
+  .news h2 { font-size: var(--fs-h2); color: #fff; position: relative; }
+  .news p { color: rgba(255,255,255,.85); max-width: 46ch; margin: .7rem auto 1.6rem; position: relative; }
+  .news form { display: flex; gap: .7rem; max-width: 460px; margin-inline: auto; position: relative; flex-wrap: wrap; justify-content: center; }
+  .news input { flex: 1 1 220px; border: none; border-radius: 999px; padding: .85rem 1.3rem; font-size: 1rem; font-family: var(--body); }
+  .news input:focus-visible { outline: 3px solid var(--clementine); }
+  .news .btn { background: var(--clementine); }
+  .news .note { display: block; margin-top: .9rem; font-size: .8rem; color: rgba(255,255,255,.75); }
+
+  /* Footer */
+  footer { border-top: 1px solid var(--line); padding: 3rem 0 2.4rem; }
+  .foot-grid { display: grid; grid-template-columns: 1.4fr 1fr 1fr; gap: 2rem; }
+  @media (max-width: 720px) { .foot-grid { grid-template-columns: 1fr; } }
+  footer h4 { font-family: var(--display); font-size: .8rem; letter-spacing: .14em; text-transform: uppercase; color: var(--ink-soft); margin: 0 0 .9rem; }
+  footer ul { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: .5rem; }
+  footer a:hover { color: var(--sky-deep); }
+  footer .fine { color: var(--ink-soft); font-size: .84rem; }
+  .foot-bottom { display: flex; justify-content: space-between; gap: 1rem; flex-wrap: wrap; margin-top: 2.6rem; padding-top: 1.4rem; border-top: 1px solid var(--line); font-size: .84rem; color: var(--ink-soft); }
+
+  @media (prefers-reduced-motion: reduce) {
+    .cloud, .rattle, .star { animation: none !important; }
+    * { scroll-behavior: auto; }
+  }
+</style>
+</head>
+<body>
+
+<header class="nav">
+  <div class="wrap nav-in">
+    <a class="brand" href="#top" aria-label="Paula's home">
+      <span class="mark" aria-hidden="true">
+        <svg viewBox="0 0 24 24" fill="none"><path d="M12 21s-7-4.35-7-9.5A3.5 3.5 0 0 1 12 8a3.5 3.5 0 0 1 7 3.5C19 16.65 12 21 12 21Z" fill="#fff"/></svg>
+      </span>
+      Paula's
+    </a>
+    <nav class="nav-links" aria-label="Primary">
+      <a href="#shop">Shop</a>
+      <a href="#categories">Categories</a>
+      <a href="#values">Our promise</a>
+      <a href="#visit">Visit us</a>
+      <a class="btn" href="#shop">Shop now</a>
+    </nav>
+  </div>
+</header>
+
+<main id="top">
+  <!-- HERO -->
+  <section class="hero">
+    <div class="wrap hero-grid">
+      <div class="hero-copy">
+        <span class="eyebrow">Handpicked · small-batch · gentle</span>
+        <h1>Little things for your <span class="swash">littlest</span> one.</h1>
+        <p class="lede">Paula's is a neighbourhood baby shop stocked with organic textiles, heirloom wooden toys, and calm nursery pieces — chosen the way we'd choose them for our own.</p>
+        <div class="hero-cta">
+          <a class="btn" href="#shop">Browse the shop</a>
+          <a class="btn ghost" href="#visit">Find the store</a>
+        </div>
+        <div class="trust">
+          <div><span class="n">2,400+</span><span class="l">happy families</span></div>
+          <div><span class="n">100%</span><span class="l">organic cottons</span></div>
+          <div><span class="n">Since '09</span><span class="l">on Maple Street</span></div>
+        </div>
+      </div>
+      <div class="scene" role="img" aria-label="A soft sky scene with clouds, stars and a floating baby rattle">
+        <span class="cloud c1"></span>
+        <span class="cloud c2"></span>
+        <svg class="star s1" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l2.2 6.6H21l-5.4 4 2.1 6.5L12 15.2 6.3 19l2.1-6.4L3 8.6h6.8z"/></svg>
+        <svg class="star s2" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l2.2 6.6H21l-5.4 4 2.1 6.5L12 15.2 6.3 19l2.1-6.4L3 8.6h6.8z"/></svg>
+        <svg class="rattle" viewBox="0 0 120 200" fill="none" aria-hidden="true">
+          <rect x="54" y="96" width="12" height="86" rx="6" fill="#EFA45C"/>
+          <circle cx="60" cy="60" r="44" fill="#fff" stroke="#7EA8C9" stroke-width="6"/>
+          <circle cx="60" cy="60" r="16" fill="#EFA45C"/>
+          <circle cx="44" cy="46" r="6" fill="#E7B0A3"/>
+          <circle cx="80" cy="52" r="5" fill="#A6BF9C"/>
+          <circle cx="60" cy="186" r="10" fill="#D9843A"/>
+        </svg>
+      </div>
+    </div>
+  </section>
+
+  <!-- CATEGORIES -->
+  <section id="categories">
+    <div class="wrap">
+      <div class="sec-head">
+        <span class="eyebrow">Shop by corner</span>
+        <h2>Four little corners of the shop</h2>
+        <p>Everything is grouped the way our shelves are — so you can find the gentle thing you came in for.</p>
+      </div>
+      <div class="cats">
+        <a class="cat" href="#shop">
+          <span class="ic" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M6 4h12l-2 4H8L6 4Z"/><path d="M8 8v10a2 2 0 0 0 2 2h4a2 2 0 0 0 2-2V8"/></svg></span>
+          <h3>Newborn essentials</h3>
+          <p>Onesies, swaddles &amp; the softest first layers.</p>
+        </a>
+        <a class="cat" href="#shop">
+          <span class="ic" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 15a9 9 0 0 1 18 0"/><circle cx="7" cy="15" r="1.4"/><circle cx="17" cy="15" r="1.4"/><path d="M2 19h20"/></svg></span>
+          <h3>Wooden toys</h3>
+          <p>Stackers, rattles &amp; toys that last for years.</p>
+        </a>
+        <a class="cat" href="#shop">
+          <span class="ic" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M4 21v-8l8-6 8 6v8"/><path d="M9 21v-5h6v5"/></svg></span>
+          <h3>Nursery</h3>
+          <p>Calm lighting, bedding &amp; sweet-dream pieces.</p>
+        </a>
+        <a class="cat" href="#shop">
+          <span class="ic" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M20 12v9H4v-9"/><path d="M2 7h20v5H2z"/><path d="M12 22V7"/><path d="M12 7S9 2 6.5 3.5 8 7 12 7ZM12 7s3-5 5.5-3.5S16 7 12 7Z"/></svg></span>
+          <h3>Gifts &amp; keepsakes</h3>
+          <p>Wrapped-and-ready sets for new arrivals.</p>
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <!-- PRODUCTS -->
+  <section id="shop">
+    <div class="wrap">
+      <div class="sec-head">
+        <span class="eyebrow">This week on the shelves</span>
+        <h2>Loved by little hands</h2>
+        <p>A rotating pick of the pieces parents keep coming back for. New arrivals land every Thursday.</p>
+      </div>
+      <div class="grid">
+        <article class="prod">
+          <div class="ph" style="background:color-mix(in srgb, var(--sky) 26%, var(--card));">
+            <span class="ribbon">Bestseller</span>
+            <svg viewBox="0 0 24 24" fill="none" stroke="var(--sky-deep)" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4h10l-2.5 4H9.5L7 4Z"/><path d="M9.5 8v11a2 2 0 0 0 2 2h1a2 2 0 0 0 2-2V8"/></svg>
+          </div>
+          <div class="body">
+            <span class="tag">Newborn</span>
+            <h3>Organic cotton onesie set</h3>
+            <p style="font-size:.9rem;color:var(--ink-soft);">Three-pack, GOTS-certified, snap closures.</p>
+            <div class="row"><span class="price">€28</span><button class="add">Add to bag</button></div>
+          </div>
+        </article>
+
+        <article class="prod">
+          <div class="ph" style="background:color-mix(in srgb, var(--clementine) 26%, var(--card));">
+            <svg viewBox="0 0 24 24" fill="none" stroke="var(--clementine-deep)" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M3 16a9 9 0 0 1 18 0"/><path d="M6 12.5a6 6 0 0 1 12 0"/><path d="M9 10a3 3 0 0 1 6 0"/><path d="M2 20h20"/></svg>
+          </div>
+          <div class="body">
+            <span class="tag">Wooden toys</span>
+            <h3>Rainbow stacking arches</h3>
+            <p style="font-size:.9rem;color:var(--ink-soft);">Seven pieces, water-based non-toxic paint.</p>
+            <div class="row"><span class="price">€34</span><button class="add">Add to bag</button></div>
+          </div>
+        </article>
+
+        <article class="prod">
+          <div class="ph" style="background:color-mix(in srgb, var(--sage) 30%, var(--card));">
+            <svg viewBox="0 0 24 24" fill="none" stroke="#557048" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M4 6h16v12H4z"/><path d="M4 6l8 6 8-6"/></svg>
+          </div>
+          <div class="body">
+            <span class="tag">Newborn</span>
+            <h3>Muslin swaddle trio</h3>
+            <p style="font-size:.9rem;color:var(--ink-soft);">Breathable double-gauze, grows into a blankie.</p>
+            <div class="row"><span class="price">€24</span><button class="add">Add to bag</button></div>
+          </div>
+        </article>
+
+        <article class="prod">
+          <div class="ph" style="background:color-mix(in srgb, var(--blush) 30%, var(--card));">
+            <svg viewBox="0 0 24 24" fill="none" stroke="#b56b5b" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="5"/><path d="M8 13c-2 1-3 3-3 6h14c0-3-1-5-3-6"/><circle cx="10" cy="8.5" r=".8" fill="#b56b5b"/><circle cx="14" cy="8.5" r=".8" fill="#b56b5b"/></svg>
+          </div>
+          <div class="body">
+            <span class="tag">Comforter</span>
+            <h3>Knit teddy comforter</h3>
+            <p style="font-size:.9rem;color:var(--ink-soft);">Hand-finished, machine-washable, tag-free.</p>
+            <div class="row"><span class="price">€19</span><button class="add">Add to bag</button></div>
+          </div>
+        </article>
+
+        <article class="prod">
+          <div class="ph" style="background:color-mix(in srgb, var(--sky) 20%, var(--clementine));">
+            <svg viewBox="0 0 24 24" fill="none" stroke="#3a2410" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M5 4h14v4a7 7 0 0 1-14 0Z"/><path d="M12 11v6"/><path d="M8 21h8"/></svg>
+          </div>
+          <div class="body">
+            <span class="tag">Bath time</span>
+            <h3>Bamboo hooded towel</h3>
+            <p style="font-size:.9rem;color:var(--ink-soft);">Extra-soft, quick-dry, with little ears.</p>
+            <div class="row"><span class="price">€22</span><button class="add">Add to bag</button></div>
+          </div>
+        </article>
+
+        <article class="prod">
+          <div class="ph" style="background:color-mix(in srgb, var(--sky-deep) 34%, var(--card));">
+            <span class="ribbon">New</span>
+            <svg viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18h6"/><path d="M10 21h4"/><path d="M12 3a6 6 0 0 0-4 10c.7.7 1 1.3 1 2h6c0-.7.3-1.3 1-2A6 6 0 0 0 12 3Z"/></svg>
+          </div>
+          <div class="body">
+            <span class="tag">Nursery</span>
+            <h3>Soft-glow night light</h3>
+            <p style="font-size:.9rem;color:var(--ink-soft);">Warm dimmable light, timer, rechargeable.</p>
+            <div class="row"><span class="price">€39</span><button class="add">Add to bag</button></div>
+          </div>
+        </article>
+      </div>
+    </div>
+  </section>
+
+  <!-- VALUES -->
+  <section id="values">
+    <div class="wrap values">
+      <div class="sec-head">
+        <span class="eyebrow">Our promise</span>
+        <h2>Why parents trust the shop</h2>
+      </div>
+      <div class="val-grid">
+        <div class="val">
+          <span class="ic" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3s7 2 7 8-4 9-7 10c-3-1-7-4-7-10s7-8 7-8Z"/><path d="M9.5 12l1.8 1.8L15 10"/></svg></span>
+          <div><h3>Skin-safe by default</h3><p>Every textile is OEKO-TEX or GOTS certified — no nasties against new skin.</p></div>
+        </div>
+        <div class="val">
+          <span class="ic" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M20 7L9 18l-5-5"/></svg></span>
+          <div><h3>Chosen, not stocked</h3><p>Paula tests everything herself. If it wouldn't do for her grandkids, it's not on the shelf.</p></div>
+        </div>
+        <div class="val">
+          <span class="ic" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="8" width="18" height="12" rx="2"/><path d="M3 8l3-4h12l3 4"/><path d="M12 4v16"/></svg></span>
+          <div><h3>Free gift wrapping</h3><p>Every order leaves the shop wrapped in recycled paper with a hand-tied ribbon.</p></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- TESTIMONIAL -->
+  <section>
+    <div class="wrap quote">
+      <div class="stars" aria-label="Five out of five stars">★★★★★</div>
+      <blockquote>"I walked in for a onesie and left with a whole first wardrobe — and Paula remembered our due date when we came back. It's the only baby shop I recommend now."</blockquote>
+      <cite>— Marisol R., mum of two &amp; regular since 2021</cite>
+    </div>
+  </section>
+
+  <!-- NEWSLETTER -->
+  <section id="visit">
+    <div class="wrap">
+      <div class="news">
+        <h2>Little notes from Paula's</h2>
+        <p>New arrivals, in-store playdates, and a €5 welcome voucher for your first visit. One gentle email a month — never more.</p>
+        <form onsubmit="event.preventDefault(); this.reset(); this.querySelector('.note').textContent='Thank you — check your inbox for the welcome voucher!';">
+          <label for="email" style="position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0 0 0 0);">Email address</label>
+          <input id="email" type="email" placeholder="you@email.com" required autocomplete="email"/>
+          <button class="btn" type="submit">Join the list</button>
+          <span class="note">We keep your address to ourselves. Unsubscribe anytime.</span>
+        </form>
+      </div>
+    </div>
+  </section>
+</main>
+
+<footer>
+  <div class="wrap">
+    <div class="foot-grid">
+      <div>
+        <a class="brand" href="#top" style="font-size:1.3rem;">
+          <span class="mark" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none"><path d="M12 21s-7-4.35-7-9.5A3.5 3.5 0 0 1 12 8a3.5 3.5 0 0 1 7 3.5C19 16.65 12 21 12 21Z" fill="#fff"/></svg></span>
+          Paula's
+        </a>
+        <p class="fine" style="margin-top:.9rem;max-width:34ch;">A little baby shop on the corner of Maple Street, run with a lot of love since 2009.</p>
+      </div>
+      <div>
+        <h4>Visit the shop</h4>
+        <ul class="fine">
+          <li>18 Maple Street</li>
+          <li>Riverside, Oakhaven</li>
+          <li>Mon–Sat · 9am–6pm</li>
+          <li>Sun · 10am–4pm</li>
+        </ul>
+      </div>
+      <div>
+        <h4>Say hello</h4>
+        <ul class="fine">
+          <li><a href="#top">hello@paulasbabyshop.example</a></li>
+          <li><a href="#top">+00 555 0148</a></li>
+          <li><a href="#top">Instagram</a></li>
+          <li><a href="#top">Gift registry</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="foot-bottom">
+      <span>© 2009–2026 Paula's Baby Shop. Made with care.</span>
+      <span>Free local delivery over €40 · Returns within 30 days</span>
+    </div>
+  </div>
+</footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds `paula-baby-shop.html` — a warm, storybook-styled single-page site for **Paula's**, a neighbourhood baby shop selling organic textiles, heirloom wooden toys, and calm nursery pieces.

## What's included

- **Cloud-scene hero** with a floating rattle motif, headline, CTAs, and trust stats
- **Shop-by-corner categories** (Newborn essentials, Wooden toys, Nursery, Gifts & keepsakes) with hand-authored inline SVG icons
- **Featured product grid** — six real products with prices, tags, and "bestseller"/"new" ribbons
- **Our promise** value props, a parent testimonial, and a working newsletter signup (client-side confirmation)
- **Footer** with store hours, address, and contact details

## Design & implementation notes

- Powder-sky + cloud visual direction on a warm-milk ground, deliberately avoiding a generic templated look
- Fully responsive (grid/flex with `gap`, no horizontal body scroll)
- Light **and** dark themes via CSS custom properties, honouring both `prefers-color-scheme` and an explicit `data-theme` toggle
- Accessible: visible focus states, ARIA labels on decorative scenes, and `prefers-reduced-motion` disables all animation
- Self-contained: all CSS inlined, no external assets or fonts

A rendered Artifact version was also published for preview.

---
_Generated by [Claude Code](https://claude.ai/code/session_015gpSWeNKt3k9Cyg7yjRXtC)_