### PR TITLE
Add sum_even_numbers helper with unit tests

### DIFF
--- a/sum_even.py
+++ b/sum_even.py
@@ -1,0 +1,40 @@
+"""Sum the even numbers in a list.
+
+Usage:
+    from sum_even import sum_even_numbers
+
+    sum_even_numbers([1, 2, 3, 4])  # -> 6
+"""
+
+from numbers import Integral
+
+
+def sum_even_numbers(numbers):
+    """Return the sum of the even numbers in ``numbers``.
+
+    Args:
+        numbers: An iterable of numbers. Integral values (``int``, ``bool``
+            and other ``numbers.Integral`` types) are tested for evenness;
+            floats with an integral value such as ``4.0`` also count as even.
+
+    Returns:
+        The sum of the even values, or ``0`` if there are none.
+
+    Raises:
+        TypeError: If an item is not a real number.
+    """
+    total = 0
+    for item in numbers:
+        if isinstance(item, Integral):
+            if item % 2 == 0:
+                total += item
+        elif isinstance(item, float):
+            if item.is_integer() and item % 2 == 0:
+                total += item
+        else:
+            raise TypeError(f"expected a real number, got {type(item).__name__}")
+    return total
+
+
+if __name__ == "__main__":
+    print(sum_even_numbers([1, 2, 3, 4, 5, 6]))

--- a/sum_even.py
+++ b/sum_even.py
@@ -3,36 +3,78 @@
 Usage:
     from sum_even import sum_even_numbers
 
-    sum_even_numbers([1, 2, 3, 4])  # -> 6
+    sum_even_numbers([1, 2, 3, 4])       # -> 6
+    sum_even_numbers([1, "2"])           # -> TypeError
+    sum_even_numbers([1, "2"], strict=False)  # -> 0 (bad items skipped)
 """
 
-from numbers import Integral
+import math
+from decimal import Decimal
+from numbers import Integral, Real
+
+__all__ = ["sum_even_numbers"]
 
 
-def sum_even_numbers(numbers):
-    """Return the sum of the even numbers in ``numbers``.
-
-    Args:
-        numbers: An iterable of numbers. Integral values (``int``, ``bool``
-            and other ``numbers.Integral`` types) are tested for evenness;
-            floats with an integral value such as ``4.0`` also count as even.
-
-    Returns:
-        The sum of the even values, or ``0`` if there are none.
+def _as_int(item):
+    """Return ``item`` as an ``int``, or raise if it is not a whole number.
 
     Raises:
-        TypeError: If an item is not a real number.
+        TypeError: If ``item`` is not a real number (strings, ``None``,
+            complex numbers, ``bool``, arbitrary objects).
+        ValueError: If ``item`` is a real number without a whole value
+            (``4.5``, ``nan``, ``inf``).
     """
+    # bool is a subclass of int, but True/False are not data points here.
+    if isinstance(item, bool) or not isinstance(item, (Real, Decimal)):
+        raise TypeError(f"expected an integer, got {type(item).__name__}: {item!r}")
+    if isinstance(item, Integral):
+        return int(item)
+    if not math.isfinite(item):
+        raise ValueError(f"expected an integer, got a non-finite value: {item!r}")
+    value = float(item)
+    if not value.is_integer():
+        raise ValueError(f"expected an integer, got a fractional value: {item!r}")
+    return int(value)
+
+
+def sum_even_numbers(numbers, strict=True):
+    """Return the sum of the even integers in ``numbers``.
+
+    Args:
+        numbers: An iterable of integers. Real values with a whole number
+            worth, such as ``4.0``, ``Fraction(4, 2)`` or ``Decimal("4")``,
+            are accepted and counted as the integer they represent.
+        strict: When ``True`` (the default), any item that is not an integer
+            raises. When ``False``, such items are skipped instead.
+
+    Returns:
+        The sum of the even values as an ``int``, or ``0`` if there are none.
+
+    Raises:
+        TypeError: If ``numbers`` is not an iterable (or is a string), or —
+            when ``strict`` — if an item is not a real number.
+        ValueError: When ``strict`` and an item is a real number without a
+            whole value, such as ``4.5``, ``nan`` or ``inf``.
+    """
+    if isinstance(numbers, (str, bytes, bytearray)):
+        raise TypeError(f"expected an iterable of numbers, got {type(numbers).__name__}")
+    try:
+        items = iter(numbers)
+    except TypeError:
+        raise TypeError(
+            f"expected an iterable of numbers, got {type(numbers).__name__}"
+        ) from None
+
     total = 0
-    for item in numbers:
-        if isinstance(item, Integral):
-            if item % 2 == 0:
-                total += item
-        elif isinstance(item, float):
-            if item.is_integer() and item % 2 == 0:
-                total += item
-        else:
-            raise TypeError(f"expected a real number, got {type(item).__name__}")
+    for index, item in enumerate(items):
+        try:
+            value = _as_int(item)
+        except (TypeError, ValueError) as exc:
+            if not strict:
+                continue
+            raise type(exc)(f"item {index}: {exc}") from None
+        if value % 2 == 0:
+            total += value
     return total
 
 

--- a/tests/test_sum_even.py
+++ b/tests/test_sum_even.py
@@ -1,0 +1,46 @@
+"""Unit tests for sum_even.
+
+Stdlib-only: run with `python -m unittest discover -s tests`.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+# Make the project root importable when run from anywhere.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from sum_even import sum_even_numbers  # noqa: E402
+
+
+class TestSumEvenNumbers(unittest.TestCase):
+    def test_mixed_list(self):
+        self.assertEqual(sum_even_numbers([1, 2, 3, 4, 5, 6]), 12)
+
+    def test_empty_list(self):
+        self.assertEqual(sum_even_numbers([]), 0)
+
+    def test_no_even_numbers(self):
+        self.assertEqual(sum_even_numbers([1, 3, 5, 7]), 0)
+
+    def test_negative_numbers(self):
+        self.assertEqual(sum_even_numbers([-2, -3, -4]), -6)
+
+    def test_zero_counts_as_even(self):
+        self.assertEqual(sum_even_numbers([0, 1]), 0)
+        self.assertEqual(sum_even_numbers([0, 2]), 2)
+
+    def test_integral_floats(self):
+        self.assertEqual(sum_even_numbers([2.0, 3.0, 4.5]), 2.0)
+
+    def test_accepts_any_iterable(self):
+        self.assertEqual(sum_even_numbers(range(1, 7)), 12)
+        self.assertEqual(sum_even_numbers(x for x in [2, 3, 8]), 10)
+
+    def test_rejects_non_numbers(self):
+        with self.assertRaises(TypeError):
+            sum_even_numbers([1, 2, "four"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sum_even.py
+++ b/tests/test_sum_even.py
@@ -5,6 +5,8 @@ Stdlib-only: run with `python -m unittest discover -s tests`.
 
 import sys
 import unittest
+from decimal import Decimal
+from fractions import Fraction
 from pathlib import Path
 
 # Make the project root importable when run from anywhere.
@@ -30,16 +32,86 @@ class TestSumEvenNumbers(unittest.TestCase):
         self.assertEqual(sum_even_numbers([0, 1]), 0)
         self.assertEqual(sum_even_numbers([0, 2]), 2)
 
-    def test_integral_floats(self):
-        self.assertEqual(sum_even_numbers([2.0, 3.0, 4.5]), 2.0)
-
     def test_accepts_any_iterable(self):
         self.assertEqual(sum_even_numbers(range(1, 7)), 12)
         self.assertEqual(sum_even_numbers(x for x in [2, 3, 8]), 10)
 
-    def test_rejects_non_numbers(self):
+
+class TestWholeNumberValues(unittest.TestCase):
+    """Real values worth a whole number are accepted and normalised to int."""
+
+    def test_integral_floats(self):
+        result = sum_even_numbers([2.0, 3.0, 4.0])
+        self.assertEqual(result, 6)
+        self.assertIsInstance(result, int)
+
+    def test_fraction_and_decimal(self):
+        self.assertEqual(sum_even_numbers([Fraction(4, 2), Decimal("4")]), 6)
+
+
+class TestInvalidItems(unittest.TestCase):
+    """Non-integer items raise by default and are skipped when strict=False."""
+
+    def test_string_item_raises_type_error(self):
         with self.assertRaises(TypeError):
             sum_even_numbers([1, 2, "four"])
+
+    def test_none_item_raises_type_error(self):
+        with self.assertRaises(TypeError):
+            sum_even_numbers([2, None])
+
+    def test_complex_item_raises_type_error(self):
+        with self.assertRaises(TypeError):
+            sum_even_numbers([2, 3 + 2j])
+
+    def test_bool_is_not_a_number(self):
+        with self.assertRaises(TypeError):
+            sum_even_numbers([True, False])
+
+    def test_fractional_float_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            sum_even_numbers([2, 4.5])
+
+    def test_fractional_decimal_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            sum_even_numbers([Decimal("4.5")])
+
+    def test_non_finite_raises_value_error(self):
+        for value in (float("nan"), float("inf"), float("-inf")):
+            with self.subTest(value=value), self.assertRaises(ValueError):
+                sum_even_numbers([2, value])
+
+    def test_error_message_names_the_offending_index(self):
+        with self.assertRaises(TypeError) as ctx:
+            sum_even_numbers([2, 4, "six"])
+        self.assertIn("item 2", str(ctx.exception))
+        self.assertIn("'six'", str(ctx.exception))
+
+    def test_non_strict_skips_invalid_items(self):
+        self.assertEqual(
+            sum_even_numbers([1, "2", 4.5, None, 4, True], strict=False), 4
+        )
+
+    def test_non_strict_still_sums_valid_items(self):
+        self.assertEqual(sum_even_numbers(["x", 2, 6, "y"], strict=False), 8)
+
+
+class TestInvalidInput(unittest.TestCase):
+    """The argument itself must be a non-string iterable."""
+
+    def test_non_iterable_raises_type_error(self):
+        for value in (5, None, 2.5):
+            with self.subTest(value=value), self.assertRaises(TypeError):
+                sum_even_numbers(value)
+
+    def test_string_input_raises_type_error(self):
+        for value in ("24", b"24", bytearray(b"24")):
+            with self.subTest(value=value), self.assertRaises(TypeError):
+                sum_even_numbers(value)
+
+    def test_input_validation_applies_in_non_strict_mode(self):
+        with self.assertRaises(TypeError):
+            sum_even_numbers(5, strict=False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds `sum_even.py` with `sum_even_numbers(numbers, strict=True)`, which returns the sum of the even integers in an iterable (`0` when there are none, always an `int`).

- Accepts any non-string iterable — lists, `range`, generators.
- Whole-number reals are accepted and normalised to `int`: `4.0`, `Fraction(4, 2)`, `Decimal("4")`.
- Input validation on the argument: a non-iterable, or a `str`/`bytes`/`bytearray`, raises `TypeError` (a bare string would otherwise iterate character-by-character).
- Input validation per item: `TypeError` for non-real values (`"four"`, `None`, `3+2j`, arbitrary objects) and for `bool`, since `True`/`False` are `int` subclasses but not data points here; `ValueError` for real values that are not whole (`4.5`, `Decimal("4.5")`, `nan`, `inf`). Messages name the offending index, e.g. `item 2: expected an integer, got str: 'six'`.
- `strict=False` skips invalid items instead of raising; argument-level validation still applies.

## Tests

`tests/test_sum_even.py` covers mixed lists, empty input, no evens, negatives, zero, non-list iterables, whole-number reals, each validation rule above, error-message content, and non-strict skipping. 22 cases; the full repo suite (56 tests) passes under `python -m unittest discover -s tests` on Python 3.9–3.12 in CI.