### PR TITLE
Add sum_even_numbers helper with unit tests

### DIFF
--- a/sum_even_numbers.py
+++ b/sum_even_numbers.py
@@ -2,24 +2,69 @@
 Sum the even numbers in a list.
 
 Stdlib-only helper: `sum_even_numbers([1, 2, 3, 4]) -> 6`.
+
+Input is validated element by element — every value must be an integer, so
+bad data raises instead of being silently skipped. Errors name the offending
+index, which is what you want when the list came from a file or a form.
 """
+
+import math
+
+
+def _as_integer(index, value):
+    """Return `value` as an int, or raise explaining why it is not one.
+
+    Booleans are rejected on purpose: Python makes `True` an int, so a stray
+    `False` would otherwise be summed as an even number.
+    """
+    if isinstance(value, bool):
+        raise TypeError(
+            "item {}: expected an integer, got bool {!r}".format(index, value)
+        )
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        if math.isnan(value) or math.isinf(value):
+            raise ValueError(
+                "item {}: expected a finite integer, got {!r}".format(index, value)
+            )
+        if not value.is_integer():
+            raise ValueError(
+                "item {}: expected an integer, got fractional {!r}".format(index, value)
+            )
+        return int(value)
+    raise TypeError(
+        "item {}: expected an integer, got {} {!r}".format(
+            index, type(value).__name__, value
+        )
+    )
 
 
 def sum_even_numbers(numbers):
     """Return the sum of the even numbers in `numbers`.
 
-    Accepts any iterable of numbers. Integers and whole floats are both
-    considered (4 and 4.0 are even, 4.5 is not). An empty iterable — or one
-    with no even values — sums to 0.
+    Accepts any iterable of integers; whole floats count as integers (4.0 is
+    4, 4.5 is not an integer). An empty iterable — or one with no even values
+    — sums to 0. The result is always an int.
 
-    Raises TypeError if an element is not a number.
+    Raises TypeError if `numbers` is not iterable, or if an element is not a
+    number (a bool included). Raises ValueError if an element is a number but
+    not a finite whole one. Both messages name the index of the bad element.
     """
+    try:
+        items = enumerate(numbers)
+    except TypeError:
+        raise TypeError(
+            "expected an iterable of integers, got {} {!r}".format(
+                type(numbers).__name__, numbers
+            )
+        ) from None
+
     total = 0
-    for value in numbers:
-        if isinstance(value, bool) or not isinstance(value, (int, float)):
-            raise TypeError("expected a number, got {!r}".format(value))
-        if value % 2 == 0:
-            total += value
+    for index, value in items:
+        number = _as_integer(index, value)
+        if number % 2 == 0:
+            total += number
     return total
 
 

--- a/sum_even_numbers.py
+++ b/sum_even_numbers.py
@@ -1,0 +1,27 @@
+"""
+Sum the even numbers in a list.
+
+Stdlib-only helper: `sum_even_numbers([1, 2, 3, 4]) -> 6`.
+"""
+
+
+def sum_even_numbers(numbers):
+    """Return the sum of the even numbers in `numbers`.
+
+    Accepts any iterable of numbers. Integers and whole floats are both
+    considered (4 and 4.0 are even, 4.5 is not). An empty iterable — or one
+    with no even values — sums to 0.
+
+    Raises TypeError if an element is not a number.
+    """
+    total = 0
+    for value in numbers:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError("expected a number, got {!r}".format(value))
+        if value % 2 == 0:
+            total += value
+    return total
+
+
+if __name__ == "__main__":
+    print(sum_even_numbers([1, 2, 3, 4, 5, 6]))  # 12

--- a/tests/test_sum_even_numbers.py
+++ b/tests/test_sum_even_numbers.py
@@ -26,19 +26,61 @@ class SumEvenNumbersTests(unittest.TestCase):
     def test_negative_and_zero(self):
         self.assertEqual(sum_even_numbers([-4, -3, 0, 3]), -4)
 
-    def test_whole_floats_count_partial_ones_do_not(self):
-        self.assertEqual(sum_even_numbers([2.0, 4.5, 3.0]), 2.0)
-
     def test_accepts_any_iterable(self):
         self.assertEqual(sum_even_numbers(range(1, 7)), 12)
 
-    def test_booleans_rejected(self):
-        with self.assertRaises(TypeError):
-            sum_even_numbers([True, 2])
+    def test_whole_floats_count_as_integers(self):
+        result = sum_even_numbers([2.0, 3.0, 4.0])
+        self.assertEqual(result, 6)
+        self.assertIsInstance(result, int)
 
-    def test_non_numbers_rejected(self):
+
+class ValidationTests(unittest.TestCase):
+    def test_non_iterable_input_rejected(self):
+        with self.assertRaises(TypeError) as ctx:
+            sum_even_numbers(42)
+        self.assertIn("iterable", str(ctx.exception))
+
+    def test_none_input_rejected(self):
         with self.assertRaises(TypeError):
-            sum_even_numbers([1, "2"])
+            sum_even_numbers(None)
+
+    def test_string_element_rejected(self):
+        with self.assertRaises(TypeError) as ctx:
+            sum_even_numbers([2, "4"])
+        self.assertIn("str", str(ctx.exception))
+
+    def test_none_element_rejected(self):
+        with self.assertRaises(TypeError):
+            sum_even_numbers([2, None])
+
+    def test_booleans_rejected(self):
+        with self.assertRaises(TypeError) as ctx:
+            sum_even_numbers([True, 2])
+        self.assertIn("bool", str(ctx.exception))
+
+    def test_fractional_float_rejected(self):
+        with self.assertRaises(ValueError) as ctx:
+            sum_even_numbers([2, 4.5])
+        self.assertIn("fractional", str(ctx.exception))
+
+    def test_nan_rejected(self):
+        with self.assertRaises(ValueError):
+            sum_even_numbers([2, float("nan")])
+
+    def test_infinity_rejected(self):
+        with self.assertRaises(ValueError):
+            sum_even_numbers([2, float("inf")])
+
+    def test_error_names_the_offending_index(self):
+        with self.assertRaises(TypeError) as ctx:
+            sum_even_numbers([0, 2, 4, "six"])
+        self.assertIn("item 3", str(ctx.exception))
+
+    def test_validation_precedes_the_even_check(self):
+        # An odd invalid value still raises — it is not skipped as "not even".
+        with self.assertRaises(TypeError):
+            sum_even_numbers([2, "3"])
 
 
 if __name__ == "__main__":

--- a/tests/test_sum_even_numbers.py
+++ b/tests/test_sum_even_numbers.py
@@ -1,0 +1,45 @@
+"""Unit tests for sum_even_numbers.
+
+Stdlib-only: run with `python -m unittest discover -s tests`.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+# Make the project root importable when run from anywhere.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from sum_even_numbers import sum_even_numbers  # noqa: E402
+
+
+class SumEvenNumbersTests(unittest.TestCase):
+    def test_mixed_list(self):
+        self.assertEqual(sum_even_numbers([1, 2, 3, 4, 5, 6]), 12)
+
+    def test_empty_list(self):
+        self.assertEqual(sum_even_numbers([]), 0)
+
+    def test_no_even_numbers(self):
+        self.assertEqual(sum_even_numbers([1, 3, 5]), 0)
+
+    def test_negative_and_zero(self):
+        self.assertEqual(sum_even_numbers([-4, -3, 0, 3]), -4)
+
+    def test_whole_floats_count_partial_ones_do_not(self):
+        self.assertEqual(sum_even_numbers([2.0, 4.5, 3.0]), 2.0)
+
+    def test_accepts_any_iterable(self):
+        self.assertEqual(sum_even_numbers(range(1, 7)), 12)
+
+    def test_booleans_rejected(self):
+        with self.assertRaises(TypeError):
+            sum_even_numbers([True, 2])
+
+    def test_non_numbers_rejected(self):
+        with self.assertRaises(TypeError):
+            sum_even_numbers([1, "2"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Adds `sum_even_numbers.py` — a stdlib-only function that takes an iterable of integers and returns the sum of only the even ones.

```python
sum_even_numbers([1, 2, 3, 4, 5, 6])  # 12
```

Behavior:
- Works with any iterable (lists, `range`, generators), not just lists.
- Whole floats count as integers (`4.0` is `4`). The result is always an `int`.
- Empty input, or input with no even values, returns `0`.

## Input validation

Every element is validated before the even check, so bad data raises instead of being silently skipped:

| Input | Result |
| --- | --- |
| `sum_even_numbers(42)` | `TypeError: expected an iterable of integers, got int 42` |
| `sum_even_numbers([0, 2, 4, "six"])` | `TypeError: item 3: expected an integer, got str 'six'` |
| `sum_even_numbers([True, 2])` | `TypeError: item 0: expected an integer, got bool True` |
| `sum_even_numbers([2, 4.5])` | `ValueError: item 1: expected an integer, got fractional 4.5` |
| `sum_even_numbers([2, float("nan")])` | `ValueError: item 1: expected a finite integer, got nan` |

Three notes on the choices:

- **Fractional floats raise rather than being skipped.** `4.5 % 2 != 0`, so a naive implementation drops it as "not even" and returns a plausible-looking wrong total. Flagging it is the point of the validation.
- **Booleans are rejected.** Python makes `True` an `int`, so a stray `False` would otherwise be summed as an even number.
- **Errors name the index.** When the list came from a file or a form, "item 3" is the part you actually need.

## Tests

`tests/test_sum_even_numbers.py` covers the sum behavior (mixed, empty, no-even, negatives and zero, non-list iterables, whole floats) and each validation path above, including that validation precedes the even check so an invalid *odd* value still raises.

```
python -m unittest discover -s tests
```

Full repo suite passes locally (51 tests).